### PR TITLE
Use 10 GB instances, the minimum.

### DIFF
--- a/system-test/compute.js
+++ b/system-test/compute.js
@@ -1933,7 +1933,7 @@ describe('Compute', function() {
                 mode: 'READ_ONLY',
                 initializeParams: {
                   diskName: generateName('disk'),
-                  diskSizeGb: 2,
+                  diskSizeGb: 10,
                   diskType: 'pd-standard',
                   sourceImage: [
                     'projects/centos-cloud/global/images/centos-6-v20150710',


### PR DESCRIPTION
Stops a system test failure I somehow missed.