### PR TITLE
Use correct URI for Snapshot instances

### DIFF
--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -129,7 +129,6 @@ function Snapshot(scope, name) {
 
   var config = {
     parent: scope,
-    // baseUrl: '/global/snapshots',
     baseUrl: 'https://www.googleapis.com/compute/v1/projects/{{projectId}}/global/snapshots',
     /**
      * @name Snapshot#id

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -129,7 +129,8 @@ function Snapshot(scope, name) {
 
   var config = {
     parent: scope,
-    baseUrl: 'https://www.googleapis.com/compute/v1/projects/{{projectId}}/global/snapshots',
+    baseUrl:
+      'https://www.googleapis.com/compute/v1/projects/{{projectId}}/global/snapshots',
     /**
      * @name Snapshot#id
      * @type {string}

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -129,7 +129,8 @@ function Snapshot(scope, name) {
 
   var config = {
     parent: scope,
-    baseUrl: '/global/snapshots',
+    // baseUrl: '/global/snapshots',
+    baseUrl: 'https://www.googleapis.com/compute/v1/projects/{{projectId}}/global/snapshots',
     /**
      * @name Snapshot#id
      * @type {string}

--- a/system-test/compute.js
+++ b/system-test/compute.js
@@ -256,9 +256,11 @@ describe('Compute', function() {
         .create(function(err, snapshot, operation) {
           assert.ifError(err);
 
-          operation.on('error', done).on('complete', function() {
-            done();
-          });
+          operation
+            .on('error', done)
+            .on('complete', function() {
+              snapshot.getMetadata(done);
+            });
         });
     });
 

--- a/system-test/compute.js
+++ b/system-test/compute.js
@@ -256,11 +256,9 @@ describe('Compute', function() {
         .create(function(err, snapshot, operation) {
           assert.ifError(err);
 
-          operation
-            .on('error', done)
-            .on('complete', function() {
-              snapshot.getMetadata(done);
-            });
+          operation.on('error', done).on('complete', function() {
+            snapshot.getMetadata(done);
+          });
         });
     });
 

--- a/test/snapshot.js
+++ b/test/snapshot.js
@@ -72,7 +72,10 @@ describe('Snapshot', function() {
       var calledWith = snapshot.calledWith_[0];
 
       assert.strictEqual(calledWith.parent, COMPUTE);
-      assert.strictEqual(calledWith.baseUrl, 'https://www.googleapis.com/compute/v1/projects/{{projectId}}/global/snapshots');
+      assert.strictEqual(
+        calledWith.baseUrl,
+        'https://www.googleapis.com/compute/v1/projects/{{projectId}}/global/snapshots'
+      );
       assert.strictEqual(calledWith.id, SNAPSHOT_NAME);
       assert.deepEqual(calledWith.methods, {
         exists: true,

--- a/test/snapshot.js
+++ b/test/snapshot.js
@@ -72,7 +72,7 @@ describe('Snapshot', function() {
       var calledWith = snapshot.calledWith_[0];
 
       assert.strictEqual(calledWith.parent, COMPUTE);
-      assert.strictEqual(calledWith.baseUrl, '/global/snapshots');
+      assert.strictEqual(calledWith.baseUrl, 'https://www.googleapis.com/compute/v1/projects/{{projectId}}/global/snapshots');
       assert.strictEqual(calledWith.id, SNAPSHOT_NAME);
       assert.deepEqual(calledWith.methods, {
         exists: true,


### PR DESCRIPTION
Fixes #66 

The Snapshot API endpoint doesn't follow the typical hierarchy we anticipated: https://cloud.google.com/compute/docs/reference/rest/v1/snapshots/get