### PR TITLE
Do not show sample for Google API Client library

### DIFF
--- a/.cloud-repo-tools.json
+++ b/.cloud-repo-tools.json
@@ -11,13 +11,6 @@
       "file": "vms.js",
       "docs_link": "https://cloud.google.com/compute/docs",
       "description": "Get a list of virtual machine instances and log the first result.\n\n"
-    },
-    {
-      "id": "vms_api",
-      "name": "Use Google Auth and list Virtual Machines",
-      "file": "vms_api.js",
-      "docs_link": "https://cloud.google.com/compute/docs",
-      "description": "After explicit authentication, get a list of virtual machine instances and log the first result.\n\n"
     }
   ]
 }

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,7 +12,6 @@ CRoed <chris.roed@anserinnovation.com>
 Dave Gramlich <callmehiphop@gmail.com>
 Eric Uldall <ericuldall@gmail.com>
 F. Hinkelmann <fhinkel@vt.edu>
-Franziska Hinkelmann <franziska.hinkelmann@gmail.com>
 Jason Dobry <jason.dobry@gmail.com>
 Jason Dobry <jmdobry@users.noreply.github.com>
 Kevin Leung <kevinresol@users.noreply.github.com>

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ has instructions for running the samples.
 | Sample                      | Source Code                       | Try it |
 | --------------------------- | --------------------------------- | ------ |
 | List Virtual Machines | [source code](https://github.com/googleapis/nodejs-compute/blob/master/samples/vms.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-compute&page=editor&open_in_editor=samples/vms.js,samples/README.md) |
-| Use Google Auth and list Virtual Machines | [source code](https://github.com/googleapis/nodejs-compute/blob/master/samples/vms_api.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-compute&page=editor&open_in_editor=samples/vms_api.js,samples/README.md) |
 
 The [Compute Engine Node.js Client API Reference][client-docs] documentation
 also contains samples.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "Dave Gramlich <callmehiphop@gmail.com>",
     "Eric Uldall <ericuldall@gmail.com>",
     "F. Hinkelmann <fhinkel@vt.edu>",
-    "Franziska Hinkelmann <franziska.hinkelmann@gmail.com>",
     "Jason Dobry <jason.dobry@gmail.com>",
     "Jason Dobry <jmdobry@users.noreply.github.com>",
     "Kevin Leung <kevinresol@users.noreply.github.com>",

--- a/samples/README.md
+++ b/samples/README.md
@@ -13,7 +13,6 @@
 * [Before you begin](#before-you-begin)
 * [Samples](#samples)
   * [List Virtual Machines](#list-virtual-machines)
-  * [Use Google Auth and list Virtual Machines](#use-google-auth-and-list-virtual-machines)
 
 ## Before you begin
 
@@ -33,17 +32,6 @@ Get a list of virtual machine instances and log the first result.
 
 [vms_0_docs]: https://cloud.google.com/compute/docs
 [vms_0_code]: vms.js
-
-### Use Google Auth and list Virtual Machines
-
-View the [source code][vms_api_1_code].
-
-[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-compute&page=editor&open_in_editor=samples/vms_api.js,samples/README.md)
-
-After explicit authentication, get a list of virtual machine instances and log the first result.
-
-[vms_api_1_docs]: https://cloud.google.com/compute/docs
-[vms_api_1_code]: vms_api.js
 
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
 [shell_link]: https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-compute&page=editor&open_in_editor=samples/README.md


### PR DESCRIPTION
Do not list this sample in the README as it is for googleapi, not
@google-cloud.

Keep the example source code because it is
referenced [here](https://cloud.google.com/compute/docs/tutorials/nodejs-guide).

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

/cc @jmdobry 