### PR TITLE
system-test: fix delete order in cleanup function

### DIFF
--- a/system-test/compute.js
+++ b/system-test/compute.js
@@ -1565,7 +1565,13 @@ describe('Compute', function() {
         async.each(
           objects,
           function(object, callback) {
-            object.delete(compute.execAfterOperation_(callback));
+            object.delete(
+              compute.execAfterOperation_(function(err) {
+                if (err) {
+                  callback(err);
+                }
+              })
+            );
           },
           callback
         );


### PR DESCRIPTION
CI is currently flaky/broken in the cleanup function. Hopefully this fixes it. 

Firewalls must be deleted before networks.
Only call the callback when all deletes have finished or if an error occurred. 
Otherwise the deletes are not happening in the correct order. 

async.forEach runs only a single async operation at a time, but the callback is called after
every single deletion and therefore too early.
