### PR TITLE
Fix problem with multiple deletes in test

### DIFF
--- a/samples/startup-script/index.js
+++ b/samples/startup-script/index.js
@@ -66,12 +66,14 @@ function createVm(name, callback) {
       console.log('Booting new VM with IP http://' + ip + '...');
 
       // Ping the VM to determine when the HTTP server is ready.
+      let waiting = true;
       const timer = setInterval(
         ip => {
           http
             .get('http://' + ip, res => {
               const statusCode = res.statusCode;
-              if (statusCode === 200) {
+              if (statusCode === 200 && waiting) {
+                waiting = false;
                 clearTimeout(timer);
                 // HTTP server is ready.
                 console.log('Ready!');


### PR DESCRIPTION
Made the test more robust. Callbacks could already be queued before the first successful ping is executed. I can reproduce this locally with a lower timeout and this fixes it.

https://circleci.com/gh/googleapis/nodejs-compute/2068