### PR TITLE
chore: run circle as non-root, fix npm link

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ jobs:
   node4:
     docker:
       - image: 'node:4'
+        user: node
     steps: &unit_tests_steps
       - checkout
       - run: &remove_package_lock
@@ -97,22 +98,27 @@ jobs:
   node6:
     docker:
       - image: 'node:6'
+        user: node
     steps: *unit_tests_steps
   node8:
     docker:
       - image: 'node:8'
+        user: node
     steps: *unit_tests_steps
   node9:
     docker:
       - image: 'node:9'
+        user: node
     steps: *unit_tests_steps
   node10:
     docker:
       - image: 'node:10'
+        user: node
     steps: *unit_tests_steps
   lint:
     docker:
       - image: 'node:8'
+        user: node
     steps:
       - checkout
       - run: *remove_package_lock
@@ -124,12 +130,17 @@ jobs:
             npm link @google-cloud/compute
             npm install
             cd ..
+          environment:
+            NPM_CONFIG_PREFIX: /home/node/.npm-global
       - run:
           name: Run linting.
           command: npm run lint
+          environment:
+            NPM_CONFIG_PREFIX: /home/node/.npm-global
   docs:
     docker:
       - image: 'node:8'
+        user: node
     steps:
       - checkout
       - run: *remove_package_lock
@@ -140,6 +151,7 @@ jobs:
   sample_tests:
     docker:
       - image: 'node:8'
+        user: node
     steps:
       - checkout
       - run: *remove_package_lock
@@ -155,16 +167,18 @@ jobs:
           name: Run sample tests.
           command: npm run samples-test
           environment:
+            NPM_CONFIG_PREFIX: /home/node/.npm-global
             GCLOUD_PROJECT: long-door-651
-            GOOGLE_APPLICATION_CREDENTIALS: /var/compute/.circleci/key.json
+            GOOGLE_APPLICATION_CREDENTIALS: /home/node/compute-samples/.circleci/key.json
       - run:
           name: Remove unencrypted key.
           command: rm .circleci/key.json
           when: always
-    working_directory: /var/compute/
+    working_directory: /home/node/compute-samples
   system_tests:
     docker:
       - image: 'node:8'
+        user: node
     steps:
       - checkout
       - run: *remove_package_lock
@@ -187,6 +201,7 @@ jobs:
   publish_npm:
     docker:
       - image: 'node:8'
+        user: node
     steps:
       - checkout
       - run:


### PR DESCRIPTION
For some reason this repo still had Circle running as root which broke `npm link` and `npm install` in samples in some weird random way. Fixing that.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
