### PR TITLE
fix: drop support for node.js 4.x and 9.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,32 +3,24 @@ workflows:
   version: 2
   tests:
     jobs: &workflow_jobs
-      - node4:
+      - node6:
           filters: &all_commits
             tags:
               only: /.*/
-      - node6:
-          filters: *all_commits
       - node8:
-          filters: *all_commits
-      - node9:
           filters: *all_commits
       - node10:
           filters: *all_commits
       - lint:
           requires:
-            - node4
             - node6
             - node8
-            - node9
             - node10
           filters: *all_commits
       - docs:
           requires:
-            - node4
             - node6
             - node8
-            - node9
             - node10
           filters: *all_commits
       - system_tests:
@@ -62,9 +54,9 @@ workflows:
               only: master
     jobs: *workflow_jobs
 jobs:
-  node4:
+  node6:
     docker:
-      - image: 'node:4'
+      - image: 'node:6'
         user: node
     steps: &unit_tests_steps
       - checkout
@@ -95,19 +87,9 @@ jobs:
           name: Submit coverage data to codecov.
           command: node_modules/.bin/codecov
           when: always
-  node6:
-    docker:
-      - image: 'node:6'
-        user: node
-    steps: *unit_tests_steps
   node8:
     docker:
       - image: 'node:8'
-        user: node
-    steps: *unit_tests_steps
-  node9:
-    docker:
-      - image: 'node:9'
         user: node
     steps: *unit_tests_steps
   node10:
@@ -117,7 +99,7 @@ jobs:
     steps: *unit_tests_steps
   lint:
     docker:
-      - image: 'node:8'
+      - image: 'node:10'
         user: node
     steps:
       - checkout
@@ -139,7 +121,7 @@ jobs:
             NPM_CONFIG_PREFIX: /home/node/.npm-global
   docs:
     docker:
-      - image: 'node:8'
+      - image: 'node:10'
         user: node
     steps:
       - checkout
@@ -150,7 +132,7 @@ jobs:
           command: npm run docs
   sample_tests:
     docker:
-      - image: 'node:8'
+      - image: 'node:10'
         user: node
     steps:
       - checkout
@@ -177,7 +159,7 @@ jobs:
     working_directory: /home/node/compute-samples
   system_tests:
     docker:
-      - image: 'node:8'
+      - image: 'node:10'
         user: node
     steps:
       - checkout
@@ -200,7 +182,7 @@ jobs:
           when: always
   publish_npm:
     docker:
-      - image: 'node:8'
+      - image: 'node:10'
         user: node
     steps:
       - checkout

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ system-test/*key.json
 .DS_Store
 google-cloud-logging-winston-*.tgz
 google-cloud-logging-bunyan-*.tgz
+.vscode

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "repository": "googleapis/nodejs-compute",
   "main": "./src/index.js",


### PR DESCRIPTION
BREAKING CHANGE: Removes Node.js 4.x and 9.x from the CI.  Resolves #64. 