### PR TITLE
fix: require use of `new`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ system-test/*key.json
 .DS_Store
 google-cloud-logging-winston-*.tgz
 google-cloud-logging-bunyan-*.tgz
+.vscode

--- a/src/index.js
+++ b/src/index.js
@@ -79,10 +79,6 @@ var Image = require('./image.js');
  * });
  */
 function Compute(options) {
-  if (!(this instanceof Compute)) {
-    return new Compute(options);
-  }
-
   options = common.util.normalizeArguments(this, options);
 
   var config = {

--- a/test/index.js
+++ b/test/index.js
@@ -202,12 +202,6 @@ describe('Compute', function() {
       assert(compute instanceof Compute);
     });
 
-    it('should work without new', function() {
-      assert.doesNotThrow(function() {
-        Compute({projectId: PROJECT_ID});
-      });
-    });
-
     it('should normalize the arguments', function() {
       var normalizeArgumentsCalled = false;
       var options = {};


### PR DESCRIPTION
BREAKING CHANGE: This eliminates the ability to use the API without instantiating a new `Compute` object.  Resolves #63. 