### PR TITLE
chore: assert.deelEqual => assert.deepStrictEqual

### DIFF
--- a/system-test/compute.js
+++ b/system-test/compute.js
@@ -150,7 +150,7 @@ describe('Compute', function() {
 
         assert.strictEqual(metadata.name, AUTOSCALER_NAME);
 
-        assert.deepEqual(metadata.autoscalingPolicy, {
+        assert.deepStrictEqual(metadata.autoscalingPolicy, {
           coolDownPeriodSec: 30,
           cpuUtilization: {
             utilizationTarget: 0.8,
@@ -305,8 +305,8 @@ describe('Compute', function() {
     it('should have opened the correct connections', function(done) {
       firewall.getMetadata(function(err, metadata) {
         assert.ifError(err);
-        assert.deepEqual(metadata.allowed, expectedMetadata.allowed);
-        assert.deepEqual(metadata.sourceRanges, expectedMetadata.sourceRanges);
+        assert.deepStrictEqual(metadata.allowed, expectedMetadata.allowed);
+        assert.deepStrictEqual(metadata.sourceRanges, expectedMetadata.sourceRanges);
         done();
       });
     });
@@ -545,7 +545,7 @@ describe('Compute', function() {
 
         assert.strictEqual(metadata.name, INSTANCE_GROUP_NAME);
         assert.strictEqual(metadata.description, OPTIONS.description);
-        assert.deepEqual(metadata.namedPorts, [
+        assert.deepStrictEqual(metadata.namedPorts, [
           {
             name: 'http',
             port: 80,
@@ -612,7 +612,7 @@ describe('Compute', function() {
 
           instanceGroup.getMetadata(function(err, metadata) {
             assert.ifError(err);
-            assert.deepEqual(metadata.namedPorts, [
+            assert.deepStrictEqual(metadata.namedPorts, [
               {
                 name: 'http',
                 port: 80,
@@ -1271,7 +1271,7 @@ describe('Compute', function() {
     it('should have enabled HTTP connections', function(done) {
       vm.getTags(function(err, tags) {
         assert.ifError(err);
-        assert.deepEqual(tags, ['http-server']);
+        assert.deepStrictEqual(tags, ['http-server']);
         done();
       });
     });
@@ -1402,7 +1402,7 @@ describe('Compute', function() {
           vm.getMetadata(function(err, metadata) {
             assert.ifError(err);
 
-            assert.deepEqual(metadata.metadata.items, [
+            assert.deepStrictEqual(metadata.metadata.items, [
               {
                 key: key,
                 value: value,

--- a/test/address.js
+++ b/test/address.js
@@ -92,7 +92,7 @@ describe('Address', function() {
       assert.strictEqual(calledWith.parent, regionInstance);
       assert.strictEqual(calledWith.baseUrl, '/addresses');
       assert.strictEqual(calledWith.id, ADDRESS_NAME);
-      assert.deepEqual(calledWith.methods, {
+      assert.deepStrictEqual(calledWith.methods, {
         create: true,
         exists: true,
         get: true,

--- a/test/autoscaler.js
+++ b/test/autoscaler.js
@@ -99,7 +99,7 @@ describe('Autoscaler', function() {
       assert.strictEqual(calledWith.baseUrl, '/autoscalers');
       assert.strictEqual(calledWith.id, AUTOSCALER_NAME);
       assert.strictEqual(calledWith.createMethod, createMethod);
-      assert.deepEqual(calledWith.methods, {
+      assert.deepStrictEqual(calledWith.methods, {
         create: true,
         exists: true,
         get: true,
@@ -188,7 +188,7 @@ describe('Autoscaler', function() {
         assert.strictEqual(reqOpts.method, 'PATCH');
         assert.strictEqual(reqOpts.uri, '/autoscalers');
         assert.strictEqual(reqOpts.json, metadata);
-        assert.deepEqual(metadata, {
+        assert.deepStrictEqual(metadata, {
           name: autoscaler.name,
           zone: ZONE.name,
         });

--- a/test/disk.js
+++ b/test/disk.js
@@ -32,7 +32,7 @@ var fakeUtil = extend({}, util, {
     }
 
     promisified = true;
-    assert.deepEqual(options.exclude, ['snapshot']);
+    assert.deepStrictEqual(options.exclude, ['snapshot']);
   },
 });
 
@@ -130,7 +130,7 @@ describe('Disk', function() {
       assert.strictEqual(calledWith.parent, zoneInstance);
       assert.strictEqual(calledWith.baseUrl, '/disks');
       assert.strictEqual(calledWith.id, DISK_NAME);
-      assert.deepEqual(calledWith.methods, {
+      assert.deepStrictEqual(calledWith.methods, {
         create: true,
         exists: true,
         get: true,
@@ -151,7 +151,7 @@ describe('Disk', function() {
       disk.request = function(reqOpts) {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/createSnapshot');
-        assert.deepEqual(reqOpts.json, {name: 'test', a: 'b'});
+        assert.deepStrictEqual(reqOpts.json, {name: 'test', a: 'b'});
         done();
       };
 

--- a/test/firewall.js
+++ b/test/firewall.js
@@ -77,7 +77,7 @@ describe('Firewall', function() {
     });
 
     it('should default to the global network', function() {
-      assert.deepEqual(firewall.metadata, {network: FIREWALL_NETWORK});
+      assert.deepStrictEqual(firewall.metadata, {network: FIREWALL_NETWORK});
     });
 
     it('should inherit from ServiceObject', function() {
@@ -98,7 +98,7 @@ describe('Firewall', function() {
       assert.strictEqual(calledWith.parent, computeInstance);
       assert.strictEqual(calledWith.baseUrl, '/global/firewalls');
       assert.strictEqual(calledWith.id, FIREWALL_NAME);
-      assert.deepEqual(calledWith.methods, {
+      assert.deepStrictEqual(calledWith.methods, {
         create: true,
         exists: true,
         get: true,
@@ -187,7 +187,7 @@ describe('Firewall', function() {
         assert.strictEqual(reqOpts.method, 'PATCH');
         assert.strictEqual(reqOpts.uri, '');
         assert.strictEqual(reqOpts.json, metadata);
-        assert.deepEqual(metadata, {
+        assert.deepStrictEqual(metadata, {
           name: firewall.name,
           network: FIREWALL_NETWORK,
         });

--- a/test/health-check.js
+++ b/test/health-check.js
@@ -73,7 +73,7 @@ describe('HealthCheck', function() {
 
       assert.strictEqual(calledWith.parent, COMPUTE);
       assert.strictEqual(calledWith.id, HEALTH_CHECK_NAME);
-      assert.deepEqual(calledWith.methods, {
+      assert.deepStrictEqual(calledWith.methods, {
         create: true,
         exists: true,
         get: true,
@@ -101,8 +101,8 @@ describe('HealthCheck', function() {
 
         COMPUTE.createHealthCheck = function(name, opts, callback) {
           assert.strictEqual(name, NAME);
-          assert.deepEqual(opts, OPTIONS);
-          assert.deepEqual(OPTIONS, originalOptions);
+          assert.deepStrictEqual(opts, OPTIONS);
+          assert.deepStrictEqual(OPTIONS, originalOptions);
           callback(); // done()
         };
 
@@ -113,7 +113,7 @@ describe('HealthCheck', function() {
         var createMethod = healthCheck.calledWith_[0].createMethod;
 
         COMPUTE.createHealthCheck = function(name, opts, callback) {
-          assert.deepEqual(opts, {});
+          assert.deepStrictEqual(opts, {});
           callback(); // done()
         };
 
@@ -145,8 +145,8 @@ describe('HealthCheck', function() {
 
         COMPUTE.createHealthCheck = function(name, opts, callback) {
           assert.strictEqual(name, NAME);
-          assert.deepEqual(opts, extend({https: true}, OPTIONS));
-          assert.deepEqual(OPTIONS, originalOptions);
+          assert.deepStrictEqual(opts, extend({https: true}, OPTIONS));
+          assert.deepStrictEqual(OPTIONS, originalOptions);
           callback(); // done()
         };
 
@@ -157,7 +157,7 @@ describe('HealthCheck', function() {
         var createMethod = healthCheck.calledWith_[0].createMethod;
 
         COMPUTE.createHealthCheck = function(name, opts, callback) {
-          assert.deepEqual(opts, {https: true});
+          assert.deepStrictEqual(opts, {https: true});
           callback(); // done()
         };
 

--- a/test/index.js
+++ b/test/index.js
@@ -37,7 +37,7 @@ var fakeUtil = extend({}, util, {
     }
 
     promisified = true;
-    assert.deepEqual(options.exclude, [
+    assert.deepStrictEqual(options.exclude, [
       'address',
       'autoscaler',
       'disk',
@@ -68,7 +68,7 @@ var fakePaginator = {
     }
 
     methods = arrify(methods);
-    assert.deepEqual(methods, [
+    assert.deepStrictEqual(methods, [
       'getAddresses',
       'getAutoscalers',
       'getDisks',
@@ -223,10 +223,10 @@ describe('Compute', function() {
 
       var baseUrl = 'https://www.googleapis.com/compute/v1';
       assert.strictEqual(calledWith.baseUrl, baseUrl);
-      assert.deepEqual(calledWith.scopes, [
+      assert.deepStrictEqual(calledWith.scopes, [
         'https://www.googleapis.com/auth/compute',
       ]);
-      assert.deepEqual(calledWith.packageJson, require('../package.json'));
+      assert.deepStrictEqual(calledWith.packageJson, require('../package.json'));
     });
 
     it('should streamify the correct methods', function() {
@@ -284,7 +284,7 @@ describe('Compute', function() {
         };
 
         compute.request = function(reqOpts) {
-          assert.deepEqual(reqOpts.json.allowed, [
+          assert.deepStrictEqual(reqOpts.json.allowed, [
             {IPProtocol: 'http', ports: [8000]},
             {IPProtocol: 'https', ports: [8080, 9000]},
             {IPProtocol: 'ssh', ports: [22]},
@@ -305,7 +305,7 @@ describe('Compute', function() {
         };
 
         compute.request = function(reqOpts) {
-          assert.deepEqual(reqOpts.json.sourceRanges, [options.ranges]);
+          assert.deepStrictEqual(reqOpts.json.sourceRanges, [options.ranges]);
           assert.strictEqual(reqOpts.json.ranges, undefined);
           done();
         };
@@ -321,7 +321,7 @@ describe('Compute', function() {
         };
 
         compute.request = function(reqOpts) {
-          assert.deepEqual(reqOpts.json.sourceTags, [options.tags]);
+          assert.deepStrictEqual(reqOpts.json.sourceTags, [options.tags]);
           assert.strictEqual(reqOpts.json.tags, undefined);
           done();
         };
@@ -336,7 +336,7 @@ describe('Compute', function() {
       compute.request = function(reqOpts) {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/global/firewalls');
-        assert.deepEqual(reqOpts.json, {name: name});
+        assert.deepStrictEqual(reqOpts.json, {name: name});
         done();
       };
 
@@ -460,8 +460,8 @@ describe('Compute', function() {
       compute.request = function(reqOpts) {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/global/httpHealthChecks');
-        assert.deepEqual(reqOpts.json, {a: 'b', name: name});
-        assert.deepEqual(options, originalOptions);
+        assert.deepStrictEqual(reqOpts.json, {a: 'b', name: name});
+        assert.deepStrictEqual(options, originalOptions);
         done();
       };
 
@@ -507,7 +507,7 @@ describe('Compute', function() {
 
         compute.healthCheck = function(name_, options) {
           assert.strictEqual(name_, name);
-          assert.deepEqual(options.https, undefined);
+          assert.deepStrictEqual(options.https, undefined);
           return healthCheck;
         };
 
@@ -577,7 +577,7 @@ describe('Compute', function() {
       compute.request = function(reqOpts) {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/global/images');
-        assert.deepEqual(reqOpts.json, {
+        assert.deepStrictEqual(reqOpts.json, {
           name: NAME,
           sourceDisk: format('zones/{zoneName}/disks/{diskName}', {
             zoneName: DISK.zone.name,
@@ -688,7 +688,7 @@ describe('Compute', function() {
       compute.request = function(reqOpts) {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/global/networks');
-        assert.deepEqual(reqOpts.json, {name: name});
+        assert.deepStrictEqual(reqOpts.json, {name: name});
         done();
       };
 
@@ -765,8 +765,8 @@ describe('Compute', function() {
       compute.request = function(reqOpts) {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/global/forwardingRules');
-        assert.deepEqual(config, originalConfig);
-        assert.deepEqual(reqOpts.json, expectedConfig);
+        assert.deepStrictEqual(config, originalConfig);
+        assert.deepStrictEqual(reqOpts.json, expectedConfig);
         done();
       };
 
@@ -780,7 +780,7 @@ describe('Compute', function() {
 
       it('should accept an array of tags', function(done) {
         compute.request = function(reqOpts) {
-          assert.deepEqual(reqOpts.json, {
+          assert.deepStrictEqual(reqOpts.json, {
             name: NAME,
             IPAddress: CONFIG.ip,
           });
@@ -798,7 +798,7 @@ describe('Compute', function() {
 
       it('should accept an array of tags', function(done) {
         compute.request = function(reqOpts) {
-          assert.deepEqual(reqOpts.json, {
+          assert.deepStrictEqual(reqOpts.json, {
             name: NAME,
             IPProtocol: CONFIG.protocol,
           });
@@ -816,7 +816,7 @@ describe('Compute', function() {
 
       it('should accept an array of tags', function(done) {
         compute.request = function(reqOpts) {
-          assert.deepEqual(reqOpts.json, {
+          assert.deepStrictEqual(reqOpts.json, {
             name: NAME,
             portRange: CONFIG.range,
           });
@@ -892,7 +892,7 @@ describe('Compute', function() {
       compute.request = function(reqOpts) {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/global/backendServices');
-        assert.deepEqual(reqOpts.json, {name: NAME});
+        assert.deepStrictEqual(reqOpts.json, {name: NAME});
         done();
       };
 
@@ -971,7 +971,7 @@ describe('Compute', function() {
   describe('getAddresses', function() {
     it('should accept only a callback', function(done) {
       compute.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -1063,9 +1063,9 @@ describe('Compute', function() {
         compute.getAddresses(query, function(err, addresses, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(query, originalQuery);
+          assert.deepStrictEqual(query, originalQuery);
 
-          assert.deepEqual(
+          assert.deepStrictEqual(
             nextQuery,
             extend({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
@@ -1081,7 +1081,7 @@ describe('Compute', function() {
   describe('getAutoscalers', function() {
     it('should accept only a callback', function(done) {
       compute.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -1198,9 +1198,9 @@ describe('Compute', function() {
         compute.getAutoscalers(query, function(err, autoscalers, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(query, originalQuery);
+          assert.deepStrictEqual(query, originalQuery);
 
-          assert.deepEqual(
+          assert.deepStrictEqual(
             nextQuery,
             extend({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
@@ -1216,7 +1216,7 @@ describe('Compute', function() {
   describe('getDisks', function() {
     it('should accept only a callback', function(done) {
       compute.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -1308,9 +1308,9 @@ describe('Compute', function() {
         compute.getDisks(query, function(err, disks, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(query, originalQuery);
+          assert.deepStrictEqual(query, originalQuery);
 
-          assert.deepEqual(
+          assert.deepStrictEqual(
             nextQuery,
             extend({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
@@ -1326,7 +1326,7 @@ describe('Compute', function() {
   describe('getFirewalls', function() {
     it('should accept only a callback', function(done) {
       compute.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -1404,9 +1404,9 @@ describe('Compute', function() {
         compute.getFirewalls(query, function(err, firewalls, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(query, originalQuery);
+          assert.deepStrictEqual(query, originalQuery);
 
-          assert.deepEqual(
+          assert.deepStrictEqual(
             nextQuery,
             extend({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
@@ -1422,7 +1422,7 @@ describe('Compute', function() {
   describe('getHealthChecks', function() {
     it('should accept only a callback', function(done) {
       compute.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -1434,7 +1434,7 @@ describe('Compute', function() {
 
       compute.request = function(reqOpts) {
         assert.strictEqual(reqOpts.uri, '/global/httpHealthChecks');
-        assert.deepEqual(reqOpts.qs, options);
+        assert.deepStrictEqual(reqOpts.qs, options);
         done();
       };
 
@@ -1448,8 +1448,8 @@ describe('Compute', function() {
 
         compute.request = function(reqOpts) {
           assert.strictEqual(reqOpts.uri, '/global/httpsHealthChecks');
-          assert.deepEqual(reqOpts.qs, {});
-          assert.deepEqual(options, originalOptions);
+          assert.deepStrictEqual(reqOpts.qs, {});
+          assert.deepStrictEqual(options, originalOptions);
           done();
         };
 
@@ -1526,9 +1526,9 @@ describe('Compute', function() {
         compute.getHealthChecks(query, function(err, firewalls, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(query, originalQuery);
+          assert.deepStrictEqual(query, originalQuery);
 
-          assert.deepEqual(
+          assert.deepStrictEqual(
             nextQuery,
             extend({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
@@ -1544,7 +1544,7 @@ describe('Compute', function() {
   describe('getImages', function() {
     it('should accept only a callback', function(done) {
       compute.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -1622,9 +1622,9 @@ describe('Compute', function() {
         compute.getImages(query, function(err, images, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(query, originalQuery);
+          assert.deepStrictEqual(query, originalQuery);
 
-          assert.deepEqual(
+          assert.deepStrictEqual(
             nextQuery,
             extend({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
@@ -1640,7 +1640,7 @@ describe('Compute', function() {
   describe('getInstanceGroups', function() {
     it('should accept only a callback', function(done) {
       compute.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -1652,7 +1652,7 @@ describe('Compute', function() {
 
       compute.request = function(reqOpts) {
         assert.strictEqual(reqOpts.uri, '/aggregated/instanceGroups');
-        assert.deepEqual(reqOpts.qs, options);
+        assert.deepStrictEqual(reqOpts.qs, options);
         done();
       };
 
@@ -1734,9 +1734,9 @@ describe('Compute', function() {
         compute.getInstanceGroups(query, function(err, groups, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(query, originalQuery);
+          assert.deepStrictEqual(query, originalQuery);
 
-          assert.deepEqual(
+          assert.deepStrictEqual(
             nextQuery,
             extend({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
@@ -1752,7 +1752,7 @@ describe('Compute', function() {
   describe('getMachineTypes', function() {
     it('should accept only a callback', function(done) {
       compute.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -1850,9 +1850,9 @@ describe('Compute', function() {
         compute.getMachineTypes(query, function(err, machineTypes, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(query, originalQuery);
+          assert.deepStrictEqual(query, originalQuery);
 
-          assert.deepEqual(
+          assert.deepStrictEqual(
             nextQuery,
             extend({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
@@ -1868,7 +1868,7 @@ describe('Compute', function() {
   describe('getNetworks', function() {
     it('should work with only a callback', function(done) {
       compute.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -1946,9 +1946,9 @@ describe('Compute', function() {
         compute.getNetworks(query, function(err, networks, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(query, originalQuery);
+          assert.deepStrictEqual(query, originalQuery);
 
-          assert.deepEqual(
+          assert.deepStrictEqual(
             nextQuery,
             extend({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
@@ -1964,7 +1964,7 @@ describe('Compute', function() {
   describe('getOperations', function() {
     it('should work with only a callback', function(done) {
       compute.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -2042,9 +2042,9 @@ describe('Compute', function() {
         compute.getOperations(query, function(err, operations, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(query, originalQuery);
+          assert.deepStrictEqual(query, originalQuery);
 
-          assert.deepEqual(
+          assert.deepStrictEqual(
             nextQuery,
             extend({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
@@ -2060,7 +2060,7 @@ describe('Compute', function() {
   describe('getRegions', function() {
     it('should work with only a callback', function(done) {
       compute.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -2138,9 +2138,9 @@ describe('Compute', function() {
         compute.getRegions(query, function(err, regions, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(query, originalQuery);
+          assert.deepStrictEqual(query, originalQuery);
 
-          assert.deepEqual(
+          assert.deepStrictEqual(
             nextQuery,
             extend({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
@@ -2156,7 +2156,7 @@ describe('Compute', function() {
   describe('getRules', function() {
     it('should work with only a callback', function(done) {
       compute.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -2219,7 +2219,7 @@ describe('Compute', function() {
 
         compute.getRules({}, function(err, rules) {
           assert.ifError(err);
-          assert.deepEqual(rules, [rule]);
+          assert.deepStrictEqual(rules, [rule]);
           done();
         });
       });
@@ -2242,9 +2242,9 @@ describe('Compute', function() {
         compute.getRules(query, function(err, rules, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(query, originalQuery);
+          assert.deepStrictEqual(query, originalQuery);
 
-          assert.deepEqual(
+          assert.deepStrictEqual(
             nextQuery,
             extend({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
@@ -2260,7 +2260,7 @@ describe('Compute', function() {
   describe('getServices', function() {
     it('should work with only a callback', function(done) {
       compute.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -2343,9 +2343,9 @@ describe('Compute', function() {
         compute.getServices(query, function(err, services, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(query, originalQuery);
+          assert.deepStrictEqual(query, originalQuery);
 
-          assert.deepEqual(
+          assert.deepStrictEqual(
             nextQuery,
             extend({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
@@ -2361,7 +2361,7 @@ describe('Compute', function() {
   describe('getSnapshots', function() {
     it('should work with only a callback', function(done) {
       compute.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -2439,9 +2439,9 @@ describe('Compute', function() {
         compute.getSnapshots(query, function(err, snapshots, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(query, originalQuery);
+          assert.deepStrictEqual(query, originalQuery);
 
-          assert.deepEqual(
+          assert.deepStrictEqual(
             nextQuery,
             extend({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
@@ -2457,7 +2457,7 @@ describe('Compute', function() {
   describe('getSubnetworks', function() {
     it('should accept only a callback', function(done) {
       compute.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -2559,9 +2559,9 @@ describe('Compute', function() {
         compute.getSubnetworks(query, function(err, subnetworks, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(query, originalQuery);
+          assert.deepStrictEqual(query, originalQuery);
 
-          assert.deepEqual(
+          assert.deepStrictEqual(
             nextQuery,
             extend({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
@@ -2577,7 +2577,7 @@ describe('Compute', function() {
   describe('getVMs', function() {
     it('should work with only a callback', function(done) {
       compute.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -2669,9 +2669,9 @@ describe('Compute', function() {
         compute.getVMs(query, function(err, vms, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(query, originalQuery);
+          assert.deepStrictEqual(query, originalQuery);
 
-          assert.deepEqual(
+          assert.deepStrictEqual(
             nextQuery,
             extend({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
@@ -2687,7 +2687,7 @@ describe('Compute', function() {
   describe('getZones', function() {
     it('should work with only a callback', function(done) {
       compute.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -2765,9 +2765,9 @@ describe('Compute', function() {
         compute.getZones(query, function(err, snapshots, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(query, originalQuery);
+          assert.deepStrictEqual(query, originalQuery);
 
-          assert.deepEqual(
+          assert.deepStrictEqual(
             nextQuery,
             extend({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,

--- a/test/instance-group.js
+++ b/test/instance-group.js
@@ -51,7 +51,7 @@ var fakePaginator = {
     extended = true;
     methods = arrify(methods);
     assert.strictEqual(Class.name, 'InstanceGroup');
-    assert.deepEqual(methods, ['getVMs']);
+    assert.deepStrictEqual(methods, ['getVMs']);
   },
   streamify: function(methodName) {
     return methodName;
@@ -123,7 +123,7 @@ describe('InstanceGroup', function() {
               assert.strictEqual(calledWith.parent, zoneInstance);
               assert.strictEqual(calledWith.baseUrl, '/instanceGroups');
               assert.strictEqual(calledWith.id, NAME);
-              assert.deepEqual(calledWith.methods, {
+              assert.deepStrictEqual(calledWith.methods, {
                 create: true,
                 exists: true,
                 get: true,
@@ -147,7 +147,7 @@ describe('InstanceGroup', function() {
     };
 
     it('should format an object of named ports', function() {
-      assert.deepEqual(InstanceGroup.formatPorts_(PORTS), [
+      assert.deepStrictEqual(InstanceGroup.formatPorts_(PORTS), [
         {name: 'http', port: 80},
         {name: 'https', port: 443},
       ]);
@@ -161,7 +161,7 @@ describe('InstanceGroup', function() {
       instanceGroup.request = function(reqOpts) {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/addInstances');
-        assert.deepEqual(reqOpts.json, {
+        assert.deepStrictEqual(reqOpts.json, {
           instances: VMS.map(function(vm) {
             return {
               instance: vm.url,
@@ -304,7 +304,7 @@ describe('InstanceGroup', function() {
 
     it('should accept only a callback', function(done) {
       instanceGroup.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -333,7 +333,7 @@ describe('InstanceGroup', function() {
 
       it('should set the instanceState filter', function(done) {
         instanceGroup.request = function(reqOpts) {
-          assert.deepEqual(reqOpts.json, {
+          assert.deepStrictEqual(reqOpts.json, {
             instanceState: 'RUNNING',
           });
           done();
@@ -391,7 +391,7 @@ describe('InstanceGroup', function() {
         instanceGroup.getVMs({}, function(err, vms, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(nextQuery, expectedNextQuery);
+          assert.deepStrictEqual(nextQuery, expectedNextQuery);
 
           done();
         });
@@ -426,7 +426,7 @@ describe('InstanceGroup', function() {
       instanceGroup.request = function(reqOpts) {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/removeInstances');
-        assert.deepEqual(reqOpts.json, {
+        assert.deepStrictEqual(reqOpts.json, {
           instances: VMS.map(function(vm) {
             return {
               instance: vm.url,

--- a/test/machine-type.js
+++ b/test/machine-type.js
@@ -67,7 +67,7 @@ describe('MachineType', function() {
       assert.strictEqual(calledWith.parent, ZONE);
       assert.strictEqual(calledWith.baseUrl, '/machineTypes');
       assert.strictEqual(calledWith.id, MACHINE_TYPE_NAME);
-      assert.deepEqual(calledWith.methods, {
+      assert.deepStrictEqual(calledWith.methods, {
         exists: true,
         get: true,
         getMetadata: true,

--- a/test/network.js
+++ b/test/network.js
@@ -32,7 +32,7 @@ var fakeUtil = extend({}, util, {
     }
 
     promisified = true;
-    assert.deepEqual(options.exclude, ['firewall']);
+    assert.deepStrictEqual(options.exclude, ['firewall']);
   },
 });
 
@@ -126,7 +126,7 @@ describe('Network', function() {
       assert.strictEqual(calledWith.parent, computeInstance);
       assert.strictEqual(calledWith.baseUrl, '/global/networks');
       assert.strictEqual(calledWith.id, NETWORK_NAME);
-      assert.deepEqual(calledWith.methods, {
+      assert.deepStrictEqual(calledWith.methods, {
         create: true,
         exists: true,
         get: true,
@@ -152,7 +152,7 @@ describe('Network', function() {
 
       network.compute.createFirewall = function(name_, config_, callback) {
         assert.strictEqual(name_, name);
-        assert.deepEqual(config_, expectedConfig);
+        assert.deepStrictEqual(config_, expectedConfig);
         callback();
       };
 
@@ -182,7 +182,7 @@ describe('Network', function() {
 
       region.createSubnetwork = function(name_, config, callback) {
         assert.strictEqual(name_, name);
-        assert.deepEqual(config, expectedConfig);
+        assert.deepStrictEqual(config, expectedConfig);
 
         callback(); // done();
       };
@@ -274,7 +274,7 @@ describe('Network', function() {
       };
 
       var firewallInstance = network.firewall(name);
-      assert.deepEqual(firewallInstance.metadata, {
+      assert.deepStrictEqual(firewallInstance.metadata, {
         network: network.formattedName,
       });
     });
@@ -288,7 +288,7 @@ describe('Network', function() {
       });
 
       network.compute.getFirewalls = function(options, callback) {
-        assert.deepEqual(options, expectedOptions);
+        assert.deepStrictEqual(options, expectedOptions);
         callback();
       };
 
@@ -312,7 +312,7 @@ describe('Network', function() {
       });
 
       network.compute.getFirewallsStream = function(options) {
-        assert.deepEqual(options, expectedOptions);
+        assert.deepStrictEqual(options, expectedOptions);
         done();
       };
 
@@ -348,7 +348,7 @@ describe('Network', function() {
       });
 
       network.compute.getSubnetworks = function(options, callback) {
-        assert.deepEqual(options, expectedOptions);
+        assert.deepStrictEqual(options, expectedOptions);
         callback();
       };
 
@@ -372,7 +372,7 @@ describe('Network', function() {
       });
 
       network.compute.getSubnetworksStream = function(options) {
-        assert.deepEqual(options, expectedOptions);
+        assert.deepStrictEqual(options, expectedOptions);
         done();
       };
 

--- a/test/operation.js
+++ b/test/operation.js
@@ -83,7 +83,7 @@ describe('Operation', function() {
       assert.strictEqual(calledWith.parent, SCOPE);
       assert.strictEqual(calledWith.baseUrl, '/operations');
       assert.strictEqual(calledWith.id, OPERATION_NAME);
-      assert.deepEqual(calledWith.methods, {
+      assert.deepStrictEqual(calledWith.methods, {
         delete: true,
         exists: true,
         get: true,

--- a/test/region.js
+++ b/test/region.js
@@ -33,7 +33,7 @@ var fakeUtil = extend({}, common.util, {
     }
 
     promisified = true;
-    assert.deepEqual(options.exclude, [
+    assert.deepStrictEqual(options.exclude, [
       'address',
       'operation',
       'rule',
@@ -79,7 +79,7 @@ var fakePaginator = {
     extended = true;
     methods = arrify(methods);
     assert.strictEqual(Class.name, 'Region');
-    assert.deepEqual(methods, [
+    assert.deepStrictEqual(methods, [
       'getAddresses',
       'getOperations',
       'getRules',
@@ -147,7 +147,7 @@ describe('Region', function() {
       assert.strictEqual(calledWith.parent, COMPUTE);
       assert.strictEqual(calledWith.baseUrl, '/regions');
       assert.strictEqual(calledWith.id, REGION_NAME);
-      assert.deepEqual(calledWith.methods, {
+      assert.deepStrictEqual(calledWith.methods, {
         exists: true,
         get: true,
         getMetadata: true,
@@ -169,7 +169,7 @@ describe('Region', function() {
         };
 
         var requestInterceptor = region.interceptors.pop().request;
-        assert.deepEqual(requestInterceptor(reqOpts), expectedReqOpts);
+        assert.deepStrictEqual(requestInterceptor(reqOpts), expectedReqOpts);
       });
 
       it('should not affect non-cancel requests', function() {
@@ -181,7 +181,7 @@ describe('Region', function() {
         };
 
         var requestInterceptor = region.interceptors.pop().request;
-        assert.deepEqual(requestInterceptor(reqOpts), expectedReqOpts);
+        assert.deepStrictEqual(requestInterceptor(reqOpts), expectedReqOpts);
       });
     });
   });
@@ -206,7 +206,7 @@ describe('Region', function() {
       var expectedBody = {name: NAME};
 
       region.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.json, expectedBody);
+        assert.deepStrictEqual(reqOpts.json, expectedBody);
         done();
       };
 
@@ -217,7 +217,7 @@ describe('Region', function() {
       region.request = function(reqOpts) {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/addresses');
-        assert.deepEqual(reqOpts.json, EXPECTED_BODY);
+        assert.deepStrictEqual(reqOpts.json, EXPECTED_BODY);
 
         done();
       };
@@ -313,7 +313,7 @@ describe('Region', function() {
       region.request = function(reqOpts) {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/subnetworks');
-        assert.deepEqual(reqOpts.json, EXPECTED_BODY);
+        assert.deepStrictEqual(reqOpts.json, EXPECTED_BODY);
 
         done();
       };
@@ -417,7 +417,7 @@ describe('Region', function() {
   describe('getAddresses', function() {
     it('should accept only a callback', function(done) {
       region.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -485,7 +485,7 @@ describe('Region', function() {
         region.getAddresses({}, function(err, addresses, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(nextQuery, expectedNextQuery);
+          assert.deepStrictEqual(nextQuery, expectedNextQuery);
 
           done();
         });
@@ -516,7 +516,7 @@ describe('Region', function() {
   describe('getOperations', function() {
     it('should accept only a callback', function(done) {
       region.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -584,7 +584,7 @@ describe('Region', function() {
         region.getOperations({}, function(err, operations, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(nextQuery, expectedNextQuery);
+          assert.deepStrictEqual(nextQuery, expectedNextQuery);
 
           done();
         });
@@ -615,7 +615,7 @@ describe('Region', function() {
   describe('getRules', function() {
     it('should accept only a callback', function(done) {
       region.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -683,7 +683,7 @@ describe('Region', function() {
         region.getRules({}, function(err, rules, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(nextQuery, expectedNextQuery);
+          assert.deepStrictEqual(nextQuery, expectedNextQuery);
 
           done();
         });
@@ -714,7 +714,7 @@ describe('Region', function() {
   describe('getSubnetworks', function() {
     it('should accept only a callback', function(done) {
       region.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -782,7 +782,7 @@ describe('Region', function() {
         region.getSubnetworks({}, function(err, subnetworks, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(nextQuery, expectedNextQuery);
+          assert.deepStrictEqual(nextQuery, expectedNextQuery);
 
           done();
         });

--- a/test/rule.js
+++ b/test/rule.js
@@ -82,7 +82,7 @@ describe('Rule', function() {
       assert.strictEqual(calledWith.baseUrl, '/global/forwardingRules');
       assert.strictEqual(calledWith.id, RULE_NAME);
       assert.strictEqual(calledWith.createMethod, bindMethod);
-      assert.deepEqual(calledWith.methods, {
+      assert.deepStrictEqual(calledWith.methods, {
         create: true,
         exists: true,
         get: true,
@@ -187,7 +187,7 @@ describe('Rule', function() {
       rule.request = function(reqOpts) {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/setTarget');
-        assert.deepEqual(reqOpts.json, {target: TARGET});
+        assert.deepStrictEqual(reqOpts.json, {target: TARGET});
 
         done();
       };

--- a/test/service.js
+++ b/test/service.js
@@ -97,7 +97,7 @@ describe('Service', function() {
       assert.strictEqual(calledWith.baseUrl, '/global/backendServices');
       assert.strictEqual(calledWith.id, SERVICE_NAME);
       assert.strictEqual(calledWith.createMethod, createMethod);
-      assert.deepEqual(calledWith.methods, {
+      assert.deepStrictEqual(calledWith.methods, {
         create: true,
         exists: true,
         get: true,
@@ -185,7 +185,7 @@ describe('Service', function() {
       service.request = function(reqOpts) {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/getHealth');
-        assert.deepEqual(reqOpts.json, {
+        assert.deepStrictEqual(reqOpts.json, {
           group: GROUP,
         });
 
@@ -203,7 +203,7 @@ describe('Service', function() {
         };
 
         service.request = function(reqOpts) {
-          assert.deepEqual(reqOpts.json, {
+          assert.deepStrictEqual(reqOpts.json, {
             group: [
               'https://www.googleapis.com/compute/v1/projects/',
               COMPUTE.projectId,
@@ -230,7 +230,7 @@ describe('Service', function() {
         };
 
         service.request = function(reqOpts) {
-          assert.deepEqual(reqOpts.json, {
+          assert.deepStrictEqual(reqOpts.json, {
             group: [
               'https://www.googleapis.com/compute/v1/projects/',
               COMPUTE.projectId,

--- a/test/snapshot.js
+++ b/test/snapshot.js
@@ -77,7 +77,7 @@ describe('Snapshot', function() {
         'https://www.googleapis.com/compute/v1/projects/{{projectId}}/global/snapshots'
       );
       assert.strictEqual(calledWith.id, SNAPSHOT_NAME);
-      assert.deepEqual(calledWith.methods, {
+      assert.deepStrictEqual(calledWith.methods, {
         exists: true,
         get: true,
         getMetadata: true,

--- a/test/subnetwork.js
+++ b/test/subnetwork.js
@@ -93,7 +93,7 @@ describe('Subnetwork', function() {
       assert.strictEqual(calledWith.baseUrl, '/subnetworks');
       assert.strictEqual(calledWith.id, SUBNETWORK_NAME);
       assert.strictEqual(calledWith.createMethod, createSubnetworkBound);
-      assert.deepEqual(calledWith.methods, {
+      assert.deepStrictEqual(calledWith.methods, {
         create: true,
         exists: true,
         get: true,

--- a/test/vm.js
+++ b/test/vm.js
@@ -105,7 +105,7 @@ describe('VM', function() {
     });
 
     it('should initialize an empty waiter array', function() {
-      assert.deepEqual(vm.waiters, []);
+      assert.deepStrictEqual(vm.waiters, []);
     });
 
     it('should localize the URL of the VM', function() {
@@ -140,7 +140,7 @@ describe('VM', function() {
       assert.strictEqual(calledWith.parent, zoneInstance);
       assert.strictEqual(calledWith.baseUrl, '/instances');
       assert.strictEqual(calledWith.id, VM_NAME);
-      assert.deepEqual(calledWith.methods, {
+      assert.deepStrictEqual(calledWith.methods, {
         create: true,
         exists: true,
         get: true,
@@ -173,7 +173,7 @@ describe('VM', function() {
 
     it('should not require an options object', function(done) {
       vm.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.json, EXPECTED_BODY);
+        assert.deepStrictEqual(reqOpts.json, EXPECTED_BODY);
         done();
       };
 
@@ -187,7 +187,7 @@ describe('VM', function() {
         var expectedBody = extend({}, EXPECTED_BODY, {mode: 'READ_ONLY'});
 
         vm.request = function(reqOpts) {
-          assert.deepEqual(reqOpts.json, expectedBody);
+          assert.deepStrictEqual(reqOpts.json, expectedBody);
           done();
         };
 
@@ -208,7 +208,7 @@ describe('VM', function() {
       vm.request = function(reqOpts, callback) {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/attachDisk');
-        assert.deepEqual(reqOpts.json, EXPECTED_BODY);
+        assert.deepStrictEqual(reqOpts.json, EXPECTED_BODY);
 
         callback();
       };
@@ -331,7 +331,7 @@ describe('VM', function() {
       vm.request = function(reqOpts, callback) {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/detachDisk');
-        assert.deepEqual(reqOpts.qs, {deviceName: DEVICE_NAME});
+        assert.deepStrictEqual(reqOpts.qs, {deviceName: DEVICE_NAME});
 
         callback();
       };
@@ -397,7 +397,7 @@ describe('VM', function() {
     it('should make the correct API request', function(done) {
       FakeServiceObject.prototype.request = function(reqOpts) {
         assert.strictEqual(reqOpts.uri, '/serialPort');
-        assert.deepEqual(reqOpts.qs, EXPECTED_QUERY);
+        assert.deepStrictEqual(reqOpts.qs, EXPECTED_QUERY);
 
         done();
       };
@@ -547,7 +547,7 @@ describe('VM', function() {
       vm.request = function(reqOpts) {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/setMachineType');
-        assert.deepEqual(reqOpts.json, {
+        assert.deepStrictEqual(reqOpts.json, {
           machineType: MACHINE_TYPE,
         });
         done();
@@ -562,7 +562,7 @@ describe('VM', function() {
       vm.request = function(reqOpts) {
         assert.strictEqual(reqOpts.method, 'POST');
         assert.strictEqual(reqOpts.uri, '/setMachineType');
-        assert.deepEqual(reqOpts.json, {
+        assert.deepStrictEqual(reqOpts.json, {
           machineType: MACHINE_TYPE,
         });
         done();
@@ -769,7 +769,7 @@ describe('VM', function() {
             vm.request = function(reqOpts, callback) {
               assert.strictEqual(reqOpts.method, 'POST');
               assert.strictEqual(reqOpts.uri, '/setMetadata');
-              assert.deepEqual(reqOpts.json, expectedNewMetadata);
+              assert.deepStrictEqual(reqOpts.json, expectedNewMetadata);
 
               callback(); // done()
             };

--- a/test/zone.js
+++ b/test/zone.js
@@ -33,7 +33,7 @@ var fakeUtil = extend({}, util, {
     }
 
     promisified = true;
-    assert.deepEqual(options.exclude, [
+    assert.deepStrictEqual(options.exclude, [
       'autoscaler',
       'disk',
       'instanceGroup',
@@ -95,7 +95,7 @@ var fakePaginator = {
     extended = true;
     methods = arrify(methods);
     assert.strictEqual(Class.name, 'Zone');
-    assert.deepEqual(methods, [
+    assert.deepStrictEqual(methods, [
       'getAutoscalers',
       'getDisks',
       'getInstanceGroups',
@@ -188,7 +188,7 @@ describe('Zone', function() {
       assert.strictEqual(calledWith.parent, COMPUTE);
       assert.strictEqual(calledWith.baseUrl, '/zones');
       assert.strictEqual(calledWith.id, ZONE_NAME);
-      assert.deepEqual(calledWith.methods, {
+      assert.deepStrictEqual(calledWith.methods, {
         exists: true,
         get: true,
         getMetadata: true,
@@ -245,7 +245,7 @@ describe('Zone', function() {
 
       zone.request = function(reqOpts) {
         var policy = reqOpts.json.autoscalingPolicy;
-        assert.deepEqual(policy, config.autoscalingPolicy);
+        assert.deepStrictEqual(policy, config.autoscalingPolicy);
         done();
       };
 
@@ -414,7 +414,7 @@ describe('Zone', function() {
         zone.request = function(reqOpts) {
           assert.strictEqual(reqOpts.method, 'POST');
           assert.strictEqual(reqOpts.uri, '/autoscalers');
-          assert.deepEqual(reqOpts.json, expectedBody);
+          assert.deepStrictEqual(reqOpts.json, expectedBody);
 
           done();
         };
@@ -547,7 +547,7 @@ describe('Zone', function() {
           zone.gceImages.getLatest = function(os, callback) {
             zone.createDisk = function(name, config, callback) {
               assert.strictEqual(name, NAME);
-              assert.deepEqual(config, expectedConfig);
+              assert.deepStrictEqual(config, expectedConfig);
               callback();
             };
 
@@ -575,8 +575,8 @@ describe('Zone', function() {
         zone.request = function(reqOpts) {
           assert.strictEqual(reqOpts.method, 'POST');
           assert.strictEqual(reqOpts.uri, '/disks');
-          assert.deepEqual(reqOpts.qs, {});
-          assert.deepEqual(reqOpts.json, expectedBody);
+          assert.deepStrictEqual(reqOpts.qs, {});
+          assert.deepStrictEqual(reqOpts.json, expectedBody);
 
           done();
         };
@@ -691,7 +691,7 @@ describe('Zone', function() {
         zone.request = function(reqOpts) {
           assert.strictEqual(reqOpts.method, 'POST');
           assert.strictEqual(reqOpts.uri, '/instanceGroups');
-          assert.deepEqual(reqOpts.json, expectedBody);
+          assert.deepStrictEqual(reqOpts.json, expectedBody);
 
           done();
         };
@@ -701,7 +701,7 @@ describe('Zone', function() {
 
       it('should not require options', function(done) {
         zone.request = function(reqOpts) {
-          assert.deepEqual(reqOpts.json, {name: NAME});
+          assert.deepStrictEqual(reqOpts.json, {name: NAME});
           done();
         };
 
@@ -808,7 +808,7 @@ describe('Zone', function() {
 
       it('should accept an array of tags', function(done) {
         zone.request = function(reqOpts) {
-          assert.deepEqual(reqOpts.json.tags.items, CONFIG.tags);
+          assert.deepStrictEqual(reqOpts.json.tags.items, CONFIG.tags);
           done();
         };
 
@@ -850,7 +850,7 @@ describe('Zone', function() {
 
       it('should add a network interface accessConfig', function(done) {
         zone.request = function(reqOpts) {
-          assert.deepEqual(reqOpts.json.networkInterfaces[0].accessConfigs[0], {
+          assert.deepStrictEqual(reqOpts.json.networkInterfaces[0].accessConfigs[0], {
             type: 'ONE_TO_ONE_NAT',
           });
           done();
@@ -879,7 +879,7 @@ describe('Zone', function() {
         var expectedTags = ['a', 'b', 'http-server'];
 
         zone.request = function(reqOpts) {
-          assert.deepEqual(reqOpts.json.tags.items, expectedTags);
+          assert.deepStrictEqual(reqOpts.json.tags.items, expectedTags);
           done();
         };
 
@@ -930,7 +930,7 @@ describe('Zone', function() {
 
       it('should add a network interface accessConfig', function(done) {
         zone.request = function(reqOpts) {
-          assert.deepEqual(reqOpts.json.networkInterfaces[0].accessConfigs[0], {
+          assert.deepStrictEqual(reqOpts.json.networkInterfaces[0].accessConfigs[0], {
             type: 'ONE_TO_ONE_NAT',
           });
           done();
@@ -959,7 +959,7 @@ describe('Zone', function() {
         var expectedTags = ['a', 'b', 'https-server'];
 
         zone.request = function(reqOpts) {
-          assert.deepEqual(reqOpts.json.tags.items, expectedTags);
+          assert.deepStrictEqual(reqOpts.json.tags.items, expectedTags);
           done();
         };
 
@@ -1028,7 +1028,7 @@ describe('Zone', function() {
           zone.gceImages.getLatest = function(os, callback) {
             zone.createVM = function(name, config, callback) {
               assert.strictEqual(name, NAME);
-              assert.deepEqual(config, expectedConfig);
+              assert.deepStrictEqual(config, expectedConfig);
               callback();
             };
 
@@ -1045,7 +1045,7 @@ describe('Zone', function() {
         zone.request = function(reqOpts) {
           assert.strictEqual(reqOpts.method, 'POST');
           assert.strictEqual(reqOpts.uri, '/instances');
-          assert.deepEqual(reqOpts.json, EXPECTED_CONFIG);
+          assert.deepStrictEqual(reqOpts.json, EXPECTED_CONFIG);
 
           done();
         };
@@ -1127,7 +1127,7 @@ describe('Zone', function() {
   describe('getAutoscalers', function() {
     it('should accept only a callback', function(done) {
       zone.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -1195,7 +1195,7 @@ describe('Zone', function() {
         zone.getAutoscalers({}, function(err, disks, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(nextQuery, expectedNextQuery);
+          assert.deepStrictEqual(nextQuery, expectedNextQuery);
 
           done();
         });
@@ -1226,7 +1226,7 @@ describe('Zone', function() {
   describe('getDisks', function() {
     it('should accept only a callback', function(done) {
       zone.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -1294,7 +1294,7 @@ describe('Zone', function() {
         zone.getDisks({}, function(err, disks, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(nextQuery, expectedNextQuery);
+          assert.deepStrictEqual(nextQuery, expectedNextQuery);
 
           done();
         });
@@ -1325,7 +1325,7 @@ describe('Zone', function() {
   describe('getInstanceGroups', function() {
     it('should accept only a callback', function(done) {
       zone.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -1393,7 +1393,7 @@ describe('Zone', function() {
         zone.getInstanceGroups({}, function(err, groups, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(nextQuery, expectedNextQuery);
+          assert.deepStrictEqual(nextQuery, expectedNextQuery);
 
           done();
         });
@@ -1429,7 +1429,7 @@ describe('Zone', function() {
       });
 
       zone.compute.getMachineTypes = function(options, callback) {
-        assert.deepEqual(options, expectedOptions);
+        assert.deepStrictEqual(options, expectedOptions);
         callback();
       };
 
@@ -1446,7 +1446,7 @@ describe('Zone', function() {
 
     it('should not require any arguments', function(done) {
       zone.compute.getMachineTypes = function(options, callback) {
-        assert.deepEqual(options, {
+        assert.deepStrictEqual(options, {
           filter: 'zone eq .*' + zone.name,
         });
         assert.strictEqual(typeof callback, 'undefined');
@@ -1470,7 +1470,7 @@ describe('Zone', function() {
   describe('getOperations', function() {
     it('should accept only a callback', function(done) {
       zone.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -1537,7 +1537,7 @@ describe('Zone', function() {
         zone.getOperations({}, function(err, operations, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(nextQuery, expectedNextQuery);
+          assert.deepStrictEqual(nextQuery, expectedNextQuery);
 
           done();
         });
@@ -1568,7 +1568,7 @@ describe('Zone', function() {
   describe('getVMs', function() {
     it('should accept only a callback', function(done) {
       zone.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -1635,7 +1635,7 @@ describe('Zone', function() {
         zone.getVMs({}, function(err, vms, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(nextQuery, expectedNextQuery);
+          assert.deepStrictEqual(nextQuery, expectedNextQuery);
 
           done();
         });
@@ -1712,7 +1712,7 @@ describe('Zone', function() {
     it('should create a firewall rule', function(done) {
       zone.compute.createFirewall = function(name, config) {
         assert.strictEqual(name, 'default-allow-http');
-        assert.deepEqual(config, {
+        assert.deepStrictEqual(config, {
           protocols: {
             tcp: [80],
           },
@@ -1760,7 +1760,7 @@ describe('Zone', function() {
     it('should create a firewall rule', function(done) {
       zone.compute.createFirewall = function(name, config) {
         assert.strictEqual(name, 'default-allow-https');
-        assert.deepEqual(config, {
+        assert.deepStrictEqual(config, {
           protocols: {
             tcp: [443],
           },


### PR DESCRIPTION
deepEqual is deprecated. Use deepStrictEqual instead