### PR TITLE
Show proper response structure in vm.getMetadata example

### DIFF
--- a/src/vm.js
+++ b/src/vm.js
@@ -227,7 +227,8 @@ function VM(zone, name) {
      * // If the callback is omitted, we'll return a Promise.
      * //-
      * vm.getMetadata().then(function(data) {
-     *   const metadata = data[0];
+     *   const operation = data[0];
+     *   const metadata = operation.metadata;
      *   const apiResponse = data[1];
      * });
      */


### PR DESCRIPTION
This updates the documentation for `vm.getMetadata` calls to show the
real response structure returned by calls using `Promise`s.

- [X] Appropriate docs were updated (if necessary)
