### PR TITLE
Use PATCH semantics by default to set custom metadata

### DIFF
--- a/src/vm.js
+++ b/src/vm.js
@@ -772,25 +772,33 @@ VM.prototype.setMetadata = function(metadata, callback) {
       return;
     }
 
-    const newMetadata = {
+    const request = {
       fingerprint: currentMetadata.metadata.fingerprint,
       items: [],
     };
 
-    for (const prop in metadata) {
-      if (metadata.hasOwnProperty(prop)) {
-        newMetadata.items.push({
-          key: prop,
-          value: metadata[prop],
-        });
+    const metadataJSON = (currentMetadata.metadata.items || []).reduce((metadataJSON, keyValPair) => {
+      metadataJSON[keyValPair.key] = keyValPair.value;
+      return metadataJSON;
+    }, {});
+
+    const newMetadataJSON = extend(metadataJSON, metadata);
+
+    for (const key in newMetadataJSON) {
+      if (newMetadataJSON.hasOwnProperty(key)) {
+        let value = newMetadataJSON[key];
+
+        if (value !== null) {
+          request.items.push({key, value});
+        }
       }
     }
 
     self.request(
       {
-        method: 'PATCH',
+        method: 'POST',
         uri: '/setMetadata',
-        json: newMetadata,
+        json: request,
       },
       callback
     );

--- a/src/vm.js
+++ b/src/vm.js
@@ -725,9 +725,11 @@ VM.prototype.resize = function(machineType, options, callback) {
 };
 
 /**
- * Set the custom metadata for this instance. This uses `PATCH` semantics by
- * default, which means that values will be overwritten with the passed in
- * metadata, but keys that were not overwritten will also exist.
+ * Set the custom metadata for this instance.
+ *
+ * This will combine the `metadata` key/value pairs with any pre-existing
+ * metadata. Any changes will override pre-existing keys. To remove a
+ * pre-existing key, explicitly set the key's value to `null`.
  *
  * @see [Instances: setMetadata API Documentation]{@link https://cloud.google.com/compute/docs/reference/v1/instances/setMetadata}
  *
@@ -745,7 +747,8 @@ VM.prototype.resize = function(machineType, options, callback) {
  * const vm = zone.vm('vm-name');
  *
  * const metadata = {
- *   'startup-script': '...'
+ *   'startup-script': '...',
+ *   customKey: null // Setting `null` will remove the `customKey` property.
  * };
  *
  * vm.setMetadata(metadata, function(err, operation, apiResponse) {
@@ -786,7 +789,7 @@ VM.prototype.setMetadata = function(metadata, callback) {
 
     for (const key in newMetadataJSON) {
       if (newMetadataJSON.hasOwnProperty(key)) {
-        let value = newMetadataJSON[key];
+        const value = newMetadataJSON[key];
 
         if (value !== null) {
           request.items.push({key, value});

--- a/src/vm.js
+++ b/src/vm.js
@@ -785,7 +785,7 @@ VM.prototype.setMetadata = function(metadata, callback) {
       return metadataJSON;
     }, {});
 
-    const newMetadataJSON = extend(metadataJSON, metadata);
+    const newMetadataJSON = Object.assign(metadataJSON, metadata);
 
     for (const key in newMetadataJSON) {
       if (newMetadataJSON.hasOwnProperty(key)) {

--- a/src/vm.js
+++ b/src/vm.js
@@ -780,10 +780,13 @@ VM.prototype.setMetadata = function(metadata, callback) {
       items: [],
     };
 
-    const metadataJSON = (currentMetadata.metadata.items || []).reduce((metadataJSON, keyValPair) => {
-      metadataJSON[keyValPair.key] = keyValPair.value;
-      return metadataJSON;
-    }, {});
+    const metadataJSON = (currentMetadata.metadata.items || []).reduce(
+      (metadataJSON, keyValPair) => {
+        metadataJSON[keyValPair.key] = keyValPair.value;
+        return metadataJSON;
+      },
+      {}
+    );
 
     const newMetadataJSON = Object.assign(metadataJSON, metadata);
 

--- a/src/vm.js
+++ b/src/vm.js
@@ -725,7 +725,9 @@ VM.prototype.resize = function(machineType, options, callback) {
 };
 
 /**
- * Set the metadata for this instance.
+ * Set the custom metadata for this instance. This uses `PATCH` semantics by
+ * default, which means that values will be overwritten with the passed in
+ * metadata, but keys that were not overwritten will also exist.
  *
  * @see [Instances: setMetadata API Documentation]{@link https://cloud.google.com/compute/docs/reference/v1/instances/setMetadata}
  *
@@ -786,7 +788,7 @@ VM.prototype.setMetadata = function(metadata, callback) {
 
     self.request(
       {
-        method: 'POST',
+        method: 'PATCH',
         uri: '/setMetadata',
         json: newMetadata,
       },

--- a/system-test/compute.js
+++ b/system-test/compute.js
@@ -1394,28 +1394,45 @@ describe('Compute', function() {
       const key = 'newKey';
       const value = 'newValue';
 
-      const newMetadata = {};
-      newMetadata[key] = value;
+      async.series([
+        next => vm.setMetadata({[key]: value}, compute.execAfterOperation_(next)),
+        next => vm.getMetadata(next),
+      ], err => {
+        assert.ifError(err);
+        assert.deepStrictEqual(vm.metadata.metadata.items, [{key, value}]);
+        done();
+      });
+    });
 
-      vm.setMetadata(
-        newMetadata,
-        compute.execAfterOperation_(function(err) {
-          assert.ifError(err);
+    it('should allow updating old metadata', function(done) {
+      const key = 'newKey';
+      const value = 'newValue';
+      const overriddenValue = `${value}${value}`;
 
-          vm.getMetadata(function(err, metadata) {
-            assert.ifError(err);
+      async.series([
+        next => vm.setMetadata({[key]: value}, compute.execAfterOperation_(next)),
+        next => vm.setMetadata({[key]: overriddenValue}, compute.execAfterOperation_(next)),
+        next => vm.getMetadata(next),
+      ], err => {
+        assert.ifError(err);
+        assert.deepStrictEqual(vm.metadata.metadata.items, [{key, value: overriddenValue}]);
+        done();
+      });
+    });
 
-            assert.deepStrictEqual(metadata.metadata.items, [
-              {
-                key: key,
-                value: value,
-              },
-            ]);
+    it.only('should allow removing old metadata', function(done) {
+      const key = 'newKey';
+      const value = 'newValue';
 
-            done();
-          });
-        })
-      );
+      async.series([
+        next => vm.setMetadata({[key]: value}, compute.execAfterOperation_(next)),
+        next => vm.setMetadata({[key]: null}, compute.execAfterOperation_(next)),
+        next => vm.getMetadata(next),
+      ], err => {
+        assert.ifError(err);
+        assert.strictEqual(vm.metadata.metadata.items, undefined);
+        done();
+      });
     });
 
     it('should start', function(done) {

--- a/system-test/compute.js
+++ b/system-test/compute.js
@@ -1420,7 +1420,7 @@ describe('Compute', function() {
       });
     });
 
-    it.only('should allow removing old metadata', function(done) {
+    it('should allow removing old metadata', function(done) {
       const key = 'newKey';
       const value = 'newValue';
 

--- a/system-test/compute.js
+++ b/system-test/compute.js
@@ -1394,14 +1394,18 @@ describe('Compute', function() {
       const key = 'newKey';
       const value = 'newValue';
 
-      async.series([
-        next => vm.setMetadata({[key]: value}, compute.execAfterOperation_(next)),
-        next => vm.getMetadata(next),
-      ], err => {
-        assert.ifError(err);
-        assert.deepStrictEqual(vm.metadata.metadata.items, [{key, value}]);
-        done();
-      });
+      async.series(
+        [
+          next =>
+            vm.setMetadata({[key]: value}, compute.execAfterOperation_(next)),
+          next => vm.getMetadata(next),
+        ],
+        err => {
+          assert.ifError(err);
+          assert.deepStrictEqual(vm.metadata.metadata.items, [{key, value}]);
+          done();
+        }
+      );
     });
 
     it('should allow updating old metadata', function(done) {
@@ -1409,30 +1413,45 @@ describe('Compute', function() {
       const value = 'newValue';
       const overriddenValue = `${value}${value}`;
 
-      async.series([
-        next => vm.setMetadata({[key]: value}, compute.execAfterOperation_(next)),
-        next => vm.setMetadata({[key]: overriddenValue}, compute.execAfterOperation_(next)),
-        next => vm.getMetadata(next),
-      ], err => {
-        assert.ifError(err);
-        assert.deepStrictEqual(vm.metadata.metadata.items, [{key, value: overriddenValue}]);
-        done();
-      });
+      async.series(
+        [
+          next =>
+            vm.setMetadata({[key]: value}, compute.execAfterOperation_(next)),
+          next =>
+            vm.setMetadata(
+              {[key]: overriddenValue},
+              compute.execAfterOperation_(next)
+            ),
+          next => vm.getMetadata(next),
+        ],
+        err => {
+          assert.ifError(err);
+          assert.deepStrictEqual(vm.metadata.metadata.items, [
+            {key, value: overriddenValue},
+          ]);
+          done();
+        }
+      );
     });
 
     it('should allow removing old metadata', function(done) {
       const key = 'newKey';
       const value = 'newValue';
 
-      async.series([
-        next => vm.setMetadata({[key]: value}, compute.execAfterOperation_(next)),
-        next => vm.setMetadata({[key]: null}, compute.execAfterOperation_(next)),
-        next => vm.getMetadata(next),
-      ], err => {
-        assert.ifError(err);
-        assert.strictEqual(vm.metadata.metadata.items, undefined);
-        done();
-      });
+      async.series(
+        [
+          next =>
+            vm.setMetadata({[key]: value}, compute.execAfterOperation_(next)),
+          next =>
+            vm.setMetadata({[key]: null}, compute.execAfterOperation_(next)),
+          next => vm.getMetadata(next),
+        ],
+        err => {
+          assert.ifError(err);
+          assert.strictEqual(vm.metadata.metadata.items, undefined);
+          done();
+        }
+      );
     });
 
     it('should start', function(done) {

--- a/test/vm.js
+++ b/test/vm.js
@@ -776,7 +776,7 @@ describe('VM', function() {
             });
 
             vm.request = function(reqOpts, callback) {
-              assert.strictEqual(reqOpts.method, 'POST');
+              assert.strictEqual(reqOpts.method, 'PATCH');
               assert.strictEqual(reqOpts.uri, '/setMetadata');
               assert.deepStrictEqual(reqOpts.json, expectedNewMetadata);
 

--- a/test/vm.js
+++ b/test/vm.js
@@ -776,7 +776,7 @@ describe('VM', function() {
             });
 
             vm.request = function(reqOpts, callback) {
-              assert.strictEqual(reqOpts.method, 'PATCH');
+              assert.strictEqual(reqOpts.method, 'POST');
               assert.strictEqual(reqOpts.uri, '/setMetadata');
               assert.deepStrictEqual(reqOpts.json, expectedNewMetadata);
 


### PR DESCRIPTION
This changes the default behavior from `POST` to `PATCH` so that the custom metadata passed into `VM#setMetadata` augments what is already set.

Fixes #168

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)