### PR TITLE
fix: Pin @types/sinon to last compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "prettier": "^1.13.5",
     "propprop": "^0.3.1",
     "proxyquire": "^2.0.1",
-    "uuid": "^3.2.1"
+    "uuid": "^3.2.1",
+    "@types/sinon": "5.0.5"
   }
 }


### PR DESCRIPTION
@types/sinon had an update over the weekend which broke many of our tests. The *real* fix is [something like this](https://github.com/googleapis/nodejs-spanner/pull/441/files), but for now, this should fix our broken CI and give us some breathing room.