### PR TITLE
refactor: use Object.assign where possible

### DIFF
--- a/src/disk.js
+++ b/src/disk.js
@@ -17,7 +17,6 @@
 'use strict';
 
 const common = require('@google-cloud/common');
-const extend = require('extend');
 const format = require('string-format-obj');
 const is = require('is');
 const {promisifyAll} = require('@google-cloud/promisify');
@@ -246,7 +245,7 @@ class Disk extends common.ServiceObject {
       {
         method: 'POST',
         uri: '/createSnapshot',
-        json: extend({}, options, {
+        json: Object.assign({}, options, {
           name: name,
         }),
       },

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,6 @@
 
 const arrify = require('arrify');
 const common = require('@google-cloud/common');
-const extend = require('extend');
 const format = require('string-format-obj');
 const is = require('is');
 const {promisifyAll} = require('@google-cloud/promisify');
@@ -156,7 +155,7 @@ class Compute extends common.Service {
     if (!is.object(config)) {
       throw new Error('A firewall configuration object must be provided.');
     }
-    const body = extend({}, config, {
+    const body = Object.assign({}, config, {
       name: name,
     });
     if (body.protocols) {
@@ -257,7 +256,7 @@ class Compute extends common.Service {
     if (!is.string(name)) {
       throw new Error('A health check name must be provided.');
     }
-    const body = extend({}, options, {
+    const body = Object.assign({}, options, {
       name: name,
     });
     const https = options.https;
@@ -333,7 +332,7 @@ class Compute extends common.Service {
       callback = options;
       options = {};
     }
-    const body = extend(
+    const body = Object.assign(
       {
         name: name,
         sourceDisk: format('zones/{zoneName}/disks/{diskName}', {
@@ -409,7 +408,7 @@ class Compute extends common.Service {
    */
   createNetwork(name, config, callback) {
     const self = this;
-    const body = extend({}, config, {
+    const body = Object.assign({}, config, {
       name: name,
     });
     if (body.range) {
@@ -498,7 +497,7 @@ class Compute extends common.Service {
    */
   createRule(name, config, callback) {
     const self = this;
-    const body = extend({}, config, {
+    const body = Object.assign({}, config, {
       name: name,
     });
     if (body.ip) {
@@ -580,7 +579,7 @@ class Compute extends common.Service {
    */
   createService(name, config, callback) {
     const self = this;
-    const body = extend({}, config, {
+    const body = Object.assign({}, config, {
       name: name,
     });
     this.request(
@@ -691,7 +690,7 @@ class Compute extends common.Service {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -788,7 +787,7 @@ class Compute extends common.Service {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -882,7 +881,7 @@ class Compute extends common.Service {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -974,7 +973,7 @@ class Compute extends common.Service {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -1066,7 +1065,7 @@ class Compute extends common.Service {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -1138,7 +1137,7 @@ class Compute extends common.Service {
       callback = options;
       options = {};
     }
-    options = extend({}, options);
+    options = Object.assign({}, options);
     const https = options.https;
     delete options.https;
     this.request(
@@ -1153,7 +1152,7 @@ class Compute extends common.Service {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -1236,7 +1235,7 @@ class Compute extends common.Service {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -1323,7 +1322,7 @@ class Compute extends common.Service {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -1414,7 +1413,7 @@ class Compute extends common.Service {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -1499,7 +1498,7 @@ class Compute extends common.Service {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -1583,7 +1582,7 @@ class Compute extends common.Service {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -1667,7 +1666,7 @@ class Compute extends common.Service {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -1752,7 +1751,7 @@ class Compute extends common.Service {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -1837,7 +1836,7 @@ class Compute extends common.Service {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -1922,7 +1921,7 @@ class Compute extends common.Service {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -2016,7 +2015,7 @@ class Compute extends common.Service {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -2106,7 +2105,7 @@ class Compute extends common.Service {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }

--- a/src/instance-group.js
+++ b/src/instance-group.js
@@ -18,7 +18,6 @@
 
 const arrify = require('arrify');
 const common = require('@google-cloud/common');
-const extend = require('extend');
 const is = require('is');
 const {promisifyAll} = require('@google-cloud/promisify');
 const {paginator} = require('@google-cloud/paginator');
@@ -378,7 +377,7 @@ class InstanceGroup extends common.ServiceObject {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }

--- a/src/network.js
+++ b/src/network.js
@@ -17,7 +17,6 @@
 'use strict';
 
 const common = require('@google-cloud/common');
-const extend = require('extend');
 const format = require('string-format-obj');
 const is = require('is');
 const {promisifyAll} = require('@google-cloud/promisify');
@@ -245,7 +244,7 @@ class Network extends common.ServiceObject {
    * });
    */
   createFirewall(name, config, callback) {
-    config = extend({}, config, {
+    config = Object.assign({}, config, {
       network: this.formattedName,
     });
     this.compute.createFirewall(name, config, callback);
@@ -304,7 +303,7 @@ class Network extends common.ServiceObject {
    * });
    */
   createSubnetwork(name, config, callback) {
-    config = extend({}, config, {
+    config = Object.assign({}, config, {
       network: this.formattedName,
     });
     let region = config.region;
@@ -376,7 +375,7 @@ class Network extends common.ServiceObject {
       callback = options;
       options = {};
     }
-    options = extend({}, options, {
+    options = Object.assign({}, options, {
       filter: 'network eq .*' + this.formattedName,
     });
     this.compute.getSubnetworks(options, callback);
@@ -413,7 +412,7 @@ class Network extends common.ServiceObject {
    *   });
    */
   getSubnetworksStream(options) {
-    options = extend({}, options, {
+    options = Object.assign({}, options, {
       filter: 'network eq .*' + this.formattedName,
     });
     return this.compute.getSubnetworksStream(options);
@@ -535,7 +534,7 @@ class Network extends common.ServiceObject {
       callback = options;
       options = {};
     }
-    options = extend({}, options, {
+    options = Object.assign({}, options, {
       filter: 'network eq .*' + this.formattedName,
     });
     this.compute.getFirewalls(options, callback);
@@ -572,7 +571,7 @@ class Network extends common.ServiceObject {
    *   });
    */
   getFirewallsStream(options) {
-    options = extend({}, options, {
+    options = Object.assign({}, options, {
       filter: 'network eq .*' + this.formattedName,
     });
     return this.compute.getFirewallsStream(options);

--- a/src/region.js
+++ b/src/region.js
@@ -17,7 +17,6 @@
 'use strict';
 
 const common = require('@google-cloud/common');
-const extend = require('extend');
 const is = require('is');
 const {promisifyAll} = require('@google-cloud/promisify');
 const {paginator} = require('@google-cloud/paginator');
@@ -218,7 +217,7 @@ class Region extends common.ServiceObject {
       {
         method: 'POST',
         uri: '/addresses',
-        json: extend({}, options, {
+        json: Object.assign({}, options, {
           name: name,
         }),
       },
@@ -288,7 +287,7 @@ class Region extends common.ServiceObject {
    */
   createSubnetwork(name, config, callback) {
     const self = this;
-    const body = extend({}, config, {
+    const body = Object.assign({}, config, {
       name: name,
     });
     if (body.network instanceof Network) {
@@ -456,7 +455,7 @@ class Region extends common.ServiceObject {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -545,7 +544,7 @@ class Region extends common.ServiceObject {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -633,7 +632,7 @@ class Region extends common.ServiceObject {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -722,7 +721,7 @@ class Region extends common.ServiceObject {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }

--- a/src/vm.js
+++ b/src/vm.js
@@ -18,7 +18,6 @@
 
 const common = require('@google-cloud/common');
 const createErrorClass = require('create-error-class');
-const extend = require('extend');
 const format = require('string-format-obj');
 const is = require('is');
 const {promisifyAll} = require('@google-cloud/promisify');
@@ -311,7 +310,7 @@ class VM extends common.ServiceObject {
       callback = options;
       options = {};
     }
-    const body = extend(
+    const body = Object.assign(
       {
         // Default the deviceName to the name of the disk, like the Console does.
         deviceName: disk.name,

--- a/src/zone.js
+++ b/src/zone.js
@@ -362,7 +362,7 @@ class Zone extends common.ServiceObject {
   createDisk(name, config, callback) {
     const self = this;
     const query = {};
-    const body = extend({}, config, {
+    const body = Object.assign({}, config, {
       name: name,
     });
     if (body.image) {
@@ -448,7 +448,7 @@ class Zone extends common.ServiceObject {
       callback = options;
       options = {};
     }
-    const body = extend({}, options, {
+    const body = Object.assign({}, options, {
       name: name,
     });
     if (body.ports) {
@@ -581,7 +581,7 @@ class Zone extends common.ServiceObject {
    */
   createVM(name, config, callback) {
     const self = this;
-    const body = extend(
+    const body = Object.assign(
       {
         name: name,
         machineType: 'n1-standard-1',
@@ -773,7 +773,7 @@ class Zone extends common.ServiceObject {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -861,7 +861,7 @@ class Zone extends common.ServiceObject {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -951,7 +951,7 @@ class Zone extends common.ServiceObject {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -1021,7 +1021,7 @@ class Zone extends common.ServiceObject {
       callback = options;
       options = {};
     }
-    options = extend({}, options, {
+    options = Object.assign({}, options, {
       filter: 'zone eq .*' + this.name,
     });
     return this.compute.getMachineTypes(options, callback);
@@ -1102,7 +1102,7 @@ class Zone extends common.ServiceObject {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }
@@ -1188,7 +1188,7 @@ class Zone extends common.ServiceObject {
         }
         let nextQuery = null;
         if (resp.nextPageToken) {
-          nextQuery = extend({}, options, {
+          nextQuery = Object.assign({}, options, {
             pageToken: resp.nextPageToken,
           });
         }

--- a/test/address.js
+++ b/test/address.js
@@ -17,13 +17,12 @@
 'use strict';
 
 const assert = require('assert');
-const extend = require('extend');
 const proxyquire = require('proxyquire');
 const {ServiceObject} = require('@google-cloud/common');
 const promisify = require('@google-cloud/promisify');
 
 let promisified = false;
-const fakePromisify = extend({}, promisify, {
+const fakePromisify = Object.assign({}, promisify, {
   promisifyAll: function(Class) {
     if (Class.name === 'Address') {
       promisified = true;
@@ -74,7 +73,7 @@ describe('Address', function() {
     });
 
     it('should inherit from ServiceObject', function(done) {
-      const regionInstance = extend({}, REGION, {
+      const regionInstance = Object.assign({}, REGION, {
         createAddress: {
           bind: function(context) {
             assert.strictEqual(context, regionInstance);

--- a/test/autoscaler.js
+++ b/test/autoscaler.js
@@ -17,13 +17,12 @@
 'use strict';
 
 const assert = require('assert');
-const extend = require('extend');
 const proxyquire = require('proxyquire');
 const {ServiceObject, util} = require('@google-cloud/common');
 const promisify = require('@google-cloud/promisify');
 
 let promisified = false;
-const fakePromisify = extend({}, promisify, {
+const fakePromisify = Object.assign({}, promisify, {
   promisifyAll: function(Class) {
     if (Class.name === 'Autoscaler') {
       promisified = true;
@@ -80,7 +79,7 @@ describe('Autoscaler', function() {
     it('should inherit from ServiceObject', function() {
       const createMethod = util.noop;
 
-      const zoneInstance = extend({}, ZONE, {
+      const zoneInstance = Object.assign({}, ZONE, {
         createAutoscaler: {
           bind: function(context) {
             assert.strictEqual(context, zoneInstance);

--- a/test/disk.js
+++ b/test/disk.js
@@ -17,14 +17,13 @@
 'use strict';
 
 const assert = require('assert');
-const extend = require('extend');
 const format = require('string-format-obj');
 const proxyquire = require('proxyquire');
 const {ServiceObject, util} = require('@google-cloud/common');
 const promisify = require('@google-cloud/promisify');
 
 let promisified = false;
-const fakePromisify = extend({}, promisify, {
+const fakePromisify = Object.assign({}, promisify, {
   promisifyAll: function(Class, options) {
     if (Class.name !== 'Disk') {
       return;
@@ -112,7 +111,7 @@ describe('Disk', function() {
     });
 
     it('should inherit from ServiceObject', function(done) {
-      const zoneInstance = extend({}, ZONE, {
+      const zoneInstance = Object.assign({}, ZONE, {
         createDisk: {
           bind: function(context) {
             assert.strictEqual(context, zoneInstance);

--- a/test/firewall.js
+++ b/test/firewall.js
@@ -17,13 +17,12 @@
 'use strict';
 
 const assert = require('assert');
-const extend = require('extend');
 const proxyquire = require('proxyquire');
 const {ServiceObject, util} = require('@google-cloud/common');
 const promisify = require('@google-cloud/promisify');
 
 let promisified = false;
-const fakePromisify = extend({}, promisify, {
+const fakePromisify = Object.assign({}, promisify, {
   promisifyAll: function(Class) {
     if (Class.name === 'Firewall') {
       promisified = true;
@@ -82,7 +81,7 @@ describe('Firewall', function() {
     });
 
     it('should inherit from ServiceObject', function() {
-      const computeInstance = extend({}, COMPUTE, {
+      const computeInstance = Object.assign({}, COMPUTE, {
         createFirewall: {
           bind: function(context) {
             assert.strictEqual(context, computeInstance);

--- a/test/health-check.js
+++ b/test/health-check.js
@@ -17,13 +17,12 @@
 'use strict';
 
 const assert = require('assert');
-const extend = require('extend');
 const proxyquire = require('proxyquire');
 const {ServiceObject, util} = require('@google-cloud/common');
 const promisify = require('@google-cloud/promisify');
 
 let promisified = false;
-const fakePromisify = extend({}, promisify, {
+const fakePromisify = Object.assign({}, promisify, {
   promisifyAll: function(Class) {
     if (Class.name === 'HealthCheck') {
       promisified = true;
@@ -88,24 +87,20 @@ describe('HealthCheck', function() {
     describe('http', function() {
       it('should set the correct baseUrl', function() {
         const calledWith = healthCheck.calledWith_[0];
-
         assert.strictEqual(calledWith.baseUrl, '/global/httpHealthChecks');
       });
 
       it('should not set options.https when created', function(done) {
         const createMethod = healthCheck.calledWith_[0].createMethod;
-
         const NAME = 'name';
         const OPTIONS = {a: 'b'};
-        const originalOptions = extend({}, OPTIONS);
-
+        const originalOptions = Object.assign({}, OPTIONS);
         COMPUTE.createHealthCheck = function(name, opts, callback) {
           assert.strictEqual(name, NAME);
           assert.deepStrictEqual(opts, OPTIONS);
           assert.deepStrictEqual(OPTIONS, originalOptions);
           callback(); // done()
         };
-
         createMethod(NAME, OPTIONS, done);
       });
 
@@ -141,11 +136,11 @@ describe('HealthCheck', function() {
 
         const NAME = 'name';
         const OPTIONS = {a: 'b'};
-        const originalOptions = extend({}, OPTIONS);
+        const originalOptions = Object.assign({}, OPTIONS);
 
         COMPUTE.createHealthCheck = function(name, opts, callback) {
           assert.strictEqual(name, NAME);
-          assert.deepStrictEqual(opts, extend({https: true}, OPTIONS));
+          assert.deepStrictEqual(opts, Object.assign({https: true}, OPTIONS));
           assert.deepStrictEqual(OPTIONS, originalOptions);
           callback(); // done()
         };

--- a/test/image.js
+++ b/test/image.js
@@ -17,13 +17,12 @@
 'use strict';
 
 const assert = require('assert');
-const extend = require('extend');
 const proxyquire = require('proxyquire');
 const {ServiceObject, util} = require('@google-cloud/common');
 const promisify = require('@google-cloud/promisify');
 
 let promisified = false;
-const fakePromisify = extend({}, promisify, {
+const fakePromisify = Object.assign({}, promisify, {
   promisifyAll: function(Class) {
     if (Class.name === 'Image') {
       promisified = true;
@@ -69,7 +68,7 @@ describe('Image', function() {
     });
 
     it('should inherit from ServiceObject', function() {
-      const computeInstance = extend({}, COMPUTE, {
+      const computeInstance = Object.assign({}, COMPUTE, {
         createImage: {
           bind: function(context) {
             assert.strictEqual(context, computeInstance);

--- a/test/index.js
+++ b/test/index.js
@@ -27,12 +27,12 @@ const promisify = require('@google-cloud/promisify');
 
 const slice = Array.prototype.slice;
 
-const fakeUtil = extend({}, util, {
+const fakeUtil = Object.assign({}, util, {
   makeAuthenticatedRequestFactory: util.noop,
 });
 
 let promisified = false;
-const fakePromisify = extend({}, promisify, {
+const fakePromisify = Object.assign({}, promisify, {
   promisifyAll: function(Class, options) {
     if (Class.name !== 'Compute') {
       return;
@@ -196,7 +196,7 @@ describe('Compute', function() {
   });
 
   beforeEach(function() {
-    extend(fakeUtil, originalFakeUtil);
+    Object.assign(fakeUtil, originalFakeUtil);
     compute = new Compute({
       projectId: PROJECT_ID,
     });
@@ -450,7 +450,7 @@ describe('Compute', function() {
     it('should make the correct default API request', function(done) {
       const name = 'new-health-check-name';
       const options = {a: 'b'};
-      const originalOptions = extend({}, options);
+      const originalOptions = Object.assign({}, options);
 
       compute.request = function(reqOpts) {
         assert.strictEqual(reqOpts.method, 'POST');
@@ -754,8 +754,8 @@ describe('Compute', function() {
 
     it('should make the correct API request', function(done) {
       const config = {a: 'b'};
-      const originalConfig = extend({}, config);
-      const expectedConfig = extend({}, config, {name: NAME});
+      const originalConfig = Object.assign({}, config);
+      const expectedConfig = Object.assign({}, config, {name: NAME});
 
       compute.request = function(reqOpts) {
         assert.strictEqual(reqOpts.method, 'POST');
@@ -1044,12 +1044,12 @@ describe('Compute', function() {
       });
 
       it('should build a nextQuery if necessary', function(done) {
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: 'next-page-token',
         });
 
         const query = {a: 'b', c: 'd'};
-        const originalQuery = extend({}, query);
+        const originalQuery = Object.assign({}, query);
 
         compute.request = function(reqOpts, callback) {
           callback(null, apiResponseWithNextPageToken);
@@ -1062,7 +1062,7 @@ describe('Compute', function() {
 
           assert.deepStrictEqual(
             nextQuery,
-            extend({}, query, {
+            Object.assign({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
             })
           );
@@ -1177,14 +1177,14 @@ describe('Compute', function() {
       });
 
       it('should build a nextQuery if necessary', function(done) {
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: 'next-page-token',
         });
 
         delete apiResponseWithNextPageToken.items;
 
         const query = {a: 'b', c: 'd'};
-        const originalQuery = extend({}, query);
+        const originalQuery = Object.assign({}, query);
 
         compute.request = function(reqOpts, callback) {
           callback(null, apiResponseWithNextPageToken);
@@ -1197,7 +1197,7 @@ describe('Compute', function() {
 
           assert.deepStrictEqual(
             nextQuery,
-            extend({}, query, {
+            Object.assign({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
             })
           );
@@ -1289,12 +1289,12 @@ describe('Compute', function() {
       });
 
       it('should build a nextQuery if necessary', function(done) {
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: 'next-page-token',
         });
 
         const query = {a: 'b', c: 'd'};
-        const originalQuery = extend({}, query);
+        const originalQuery = Object.assign({}, query);
 
         compute.request = function(reqOpts, callback) {
           callback(null, apiResponseWithNextPageToken);
@@ -1307,7 +1307,7 @@ describe('Compute', function() {
 
           assert.deepStrictEqual(
             nextQuery,
-            extend({}, query, {
+            Object.assign({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
             })
           );
@@ -1385,12 +1385,12 @@ describe('Compute', function() {
       });
 
       it('should build a nextQuery if necessary', function(done) {
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: 'next-page-token',
         });
 
         const query = {a: 'b', c: 'd'};
-        const originalQuery = extend({}, query);
+        const originalQuery = Object.assign({}, query);
 
         compute.request = function(reqOpts, callback) {
           callback(null, apiResponseWithNextPageToken);
@@ -1403,7 +1403,7 @@ describe('Compute', function() {
 
           assert.deepStrictEqual(
             nextQuery,
-            extend({}, query, {
+            Object.assign({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
             })
           );
@@ -1439,7 +1439,7 @@ describe('Compute', function() {
     describe('options.https', function() {
       it('should make the correct API request', function(done) {
         const options = {https: true};
-        const originalOptions = extend({}, options);
+        const originalOptions = Object.assign({}, options);
 
         compute.request = function(reqOpts) {
           assert.strictEqual(reqOpts.uri, '/global/httpsHealthChecks');
@@ -1507,12 +1507,12 @@ describe('Compute', function() {
       });
 
       it('should build a nextQuery if necessary', function(done) {
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: 'next-page-token',
         });
 
         const query = {a: 'b', c: 'd'};
-        const originalQuery = extend({}, query);
+        const originalQuery = Object.assign({}, query);
 
         compute.request = function(reqOpts, callback) {
           callback(null, apiResponseWithNextPageToken);
@@ -1525,7 +1525,7 @@ describe('Compute', function() {
 
           assert.deepStrictEqual(
             nextQuery,
-            extend({}, query, {
+            Object.assign({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
             })
           );
@@ -1603,12 +1603,12 @@ describe('Compute', function() {
       });
 
       it('should build a nextQuery if necessary', function(done) {
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: 'next-page-token',
         });
 
         const query = {a: 'b', c: 'd'};
-        const originalQuery = extend({}, query);
+        const originalQuery = Object.assign({}, query);
 
         compute.request = function(reqOpts, callback) {
           callback(null, apiResponseWithNextPageToken);
@@ -1621,7 +1621,7 @@ describe('Compute', function() {
 
           assert.deepStrictEqual(
             nextQuery,
-            extend({}, query, {
+            Object.assign({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
             })
           );
@@ -1713,14 +1713,14 @@ describe('Compute', function() {
       });
 
       it('should build a nextQuery if necessary', function(done) {
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: 'next-page-token',
         });
 
         delete apiResponseWithNextPageToken.items;
 
         const query = {a: 'b', c: 'd'};
-        const originalQuery = extend({}, query);
+        const originalQuery = Object.assign({}, query);
 
         compute.request = function(reqOpts, callback) {
           callback(null, apiResponseWithNextPageToken);
@@ -1733,7 +1733,7 @@ describe('Compute', function() {
 
           assert.deepStrictEqual(
             nextQuery,
-            extend({}, query, {
+            Object.assign({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
             })
           );
@@ -1831,12 +1831,12 @@ describe('Compute', function() {
       });
 
       it('should build a nextQuery if necessary', function(done) {
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: 'next-page-token',
         });
 
         const query = {a: 'b', c: 'd'};
-        const originalQuery = extend({}, query);
+        const originalQuery = Object.assign({}, query);
 
         compute.request = function(reqOpts, callback) {
           callback(null, apiResponseWithNextPageToken);
@@ -1849,7 +1849,7 @@ describe('Compute', function() {
 
           assert.deepStrictEqual(
             nextQuery,
-            extend({}, query, {
+            Object.assign({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
             })
           );
@@ -1927,12 +1927,12 @@ describe('Compute', function() {
       });
 
       it('should build a nextQuery if necessary', function(done) {
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: 'next-page-token',
         });
 
         const query = {a: 'b', c: 'd'};
-        const originalQuery = extend({}, query);
+        const originalQuery = Object.assign({}, query);
 
         compute.request = function(reqOpts, callback) {
           callback(null, apiResponseWithNextPageToken);
@@ -1945,7 +1945,7 @@ describe('Compute', function() {
 
           assert.deepStrictEqual(
             nextQuery,
-            extend({}, query, {
+            Object.assign({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
             })
           );
@@ -2023,12 +2023,12 @@ describe('Compute', function() {
       });
 
       it('should build a nextQuery if necessary', function(done) {
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: 'next-page-token',
         });
 
         const query = {a: 'b', c: 'd'};
-        const originalQuery = extend({}, query);
+        const originalQuery = Object.assign({}, query);
 
         compute.request = function(reqOpts, callback) {
           callback(null, apiResponseWithNextPageToken);
@@ -2041,7 +2041,7 @@ describe('Compute', function() {
 
           assert.deepStrictEqual(
             nextQuery,
-            extend({}, query, {
+            Object.assign({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
             })
           );
@@ -2119,12 +2119,12 @@ describe('Compute', function() {
       });
 
       it('should build a nextQuery if necessary', function(done) {
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: 'next-page-token',
         });
 
         const query = {a: 'b', c: 'd'};
-        const originalQuery = extend({}, query);
+        const originalQuery = Object.assign({}, query);
 
         compute.request = function(reqOpts, callback) {
           callback(null, apiResponseWithNextPageToken);
@@ -2137,7 +2137,7 @@ describe('Compute', function() {
 
           assert.deepStrictEqual(
             nextQuery,
-            extend({}, query, {
+            Object.assign({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
             })
           );
@@ -2220,7 +2220,7 @@ describe('Compute', function() {
       });
 
       it('should build a nextQuery if necessary', function(done) {
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: 'next-page-token',
         });
 
@@ -2228,7 +2228,7 @@ describe('Compute', function() {
           a: 'b',
           c: 'd',
         };
-        const originalQuery = extend({}, query);
+        const originalQuery = Object.assign({}, query);
 
         compute.request = function(reqOpts, callback) {
           callback(null, apiResponseWithNextPageToken);
@@ -2241,7 +2241,7 @@ describe('Compute', function() {
 
           assert.deepStrictEqual(
             nextQuery,
-            extend({}, query, {
+            Object.assign({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
             })
           );
@@ -2321,7 +2321,7 @@ describe('Compute', function() {
       });
 
       it('should build a nextQuery if necessary', function(done) {
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: 'next-page-token',
         });
 
@@ -2329,7 +2329,7 @@ describe('Compute', function() {
           a: 'b',
           c: 'd',
         };
-        const originalQuery = extend({}, query);
+        const originalQuery = Object.assign({}, query);
 
         compute.request = function(reqOpts, callback) {
           callback(null, apiResponseWithNextPageToken);
@@ -2342,7 +2342,7 @@ describe('Compute', function() {
 
           assert.deepStrictEqual(
             nextQuery,
-            extend({}, query, {
+            Object.assign({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
             })
           );
@@ -2420,12 +2420,12 @@ describe('Compute', function() {
       });
 
       it('should build a nextQuery if necessary', function(done) {
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: 'next-page-token',
         });
 
         const query = {a: 'b', c: 'd'};
-        const originalQuery = extend({}, query);
+        const originalQuery = Object.assign({}, query);
 
         compute.request = function(reqOpts, callback) {
           callback(null, apiResponseWithNextPageToken);
@@ -2438,7 +2438,7 @@ describe('Compute', function() {
 
           assert.deepStrictEqual(
             nextQuery,
-            extend({}, query, {
+            Object.assign({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
             })
           );
@@ -2540,12 +2540,12 @@ describe('Compute', function() {
       });
 
       it('should build a nextQuery if necessary', function(done) {
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: 'next-page-token',
         });
 
         const query = {a: 'b', c: 'd'};
-        const originalQuery = extend({}, query);
+        const originalQuery = Object.assign({}, query);
 
         compute.request = function(reqOpts, callback) {
           callback(null, apiResponseWithNextPageToken);
@@ -2558,7 +2558,7 @@ describe('Compute', function() {
 
           assert.deepStrictEqual(
             nextQuery,
-            extend({}, query, {
+            Object.assign({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
             })
           );
@@ -2650,12 +2650,12 @@ describe('Compute', function() {
       });
 
       it('should build a nextQuery if necessary', function(done) {
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: 'next-page-token',
         });
 
         const query = {a: 'b', c: 'd'};
-        const originalQuery = extend({}, query);
+        const originalQuery = Object.assign({}, query);
 
         compute.request = function(reqOpts, callback) {
           callback(null, apiResponseWithNextPageToken);
@@ -2668,7 +2668,7 @@ describe('Compute', function() {
 
           assert.deepStrictEqual(
             nextQuery,
-            extend({}, query, {
+            Object.assign({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
             })
           );
@@ -2746,12 +2746,12 @@ describe('Compute', function() {
       });
 
       it('should build a nextQuery if necessary', function(done) {
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: 'next-page-token',
         });
 
         const query = {a: 'b', c: 'd'};
-        const originalQuery = extend({}, query);
+        const originalQuery = Object.assign({}, query);
 
         compute.request = function(reqOpts, callback) {
           callback(null, apiResponseWithNextPageToken);
@@ -2764,7 +2764,7 @@ describe('Compute', function() {
 
           assert.deepStrictEqual(
             nextQuery,
-            extend({}, query, {
+            Object.assign({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,
             })
           );

--- a/test/instance-group.js
+++ b/test/instance-group.js
@@ -18,13 +18,12 @@
 
 const arrify = require('arrify');
 const assert = require('assert');
-const extend = require('extend');
 const proxyquire = require('proxyquire');
 const {ServiceObject, util} = require('@google-cloud/common');
 const promisify = require('@google-cloud/promisify');
 
 let promisified = false;
-const fakePromisify = extend({}, promisify, {
+const fakePromisify = Object.assign({}, promisify, {
   promisifyAll: function(Class) {
     if (Class.name === 'InstanceGroup') {
       promisified = true;
@@ -82,7 +81,7 @@ describe('InstanceGroup', function() {
   });
 
   beforeEach(function() {
-    extend(InstanceGroup, staticMethods);
+    Object.assign(InstanceGroup, staticMethods);
     instanceGroup = new InstanceGroup(ZONE, NAME);
   });
 
@@ -108,7 +107,7 @@ describe('InstanceGroup', function() {
     });
 
     it('should inherit from ServiceObject', function(done) {
-      const zoneInstance = extend({}, ZONE, {
+      const zoneInstance = Object.assign({}, ZONE, {
         createInstanceGroup: {
           bind: function(context) {
             assert.strictEqual(context, zoneInstance);
@@ -375,7 +374,7 @@ describe('InstanceGroup', function() {
 
       it('should build a nextQuery if necessary', function(done) {
         const nextPageToken = 'next-page-token';
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: nextPageToken,
         });
         const expectedNextQuery = {

--- a/test/network.js
+++ b/test/network.js
@@ -17,14 +17,13 @@
 'use strict';
 
 const assert = require('assert');
-const extend = require('extend');
 const format = require('string-format-obj');
 const proxyquire = require('proxyquire');
 const {ServiceObject, util} = require('@google-cloud/common');
 const promisify = require('@google-cloud/promisify');
 
 let promisified = false;
-const fakePromisify = extend({}, promisify, {
+const fakePromisify = Object.assign({}, promisify, {
   promisifyAll: function(Class, options) {
     if (Class.name !== 'Network') {
       return;
@@ -107,7 +106,7 @@ describe('Network', function() {
     });
 
     it('should inherit from ServiceObject', function(done) {
-      const computeInstance = extend({}, COMPUTE, {
+      const computeInstance = Object.assign({}, COMPUTE, {
         createNetwork: {
           bind: function(context) {
             assert.strictEqual(context, computeInstance);
@@ -144,7 +143,7 @@ describe('Network', function() {
     it('should make the correct call to Compute', function(done) {
       const name = 'firewall-name';
       const config = {a: 'b', c: 'd'};
-      const expectedConfig = extend({}, config, {
+      const expectedConfig = Object.assign({}, config, {
         network: network.formattedName,
       });
 
@@ -168,7 +167,7 @@ describe('Network', function() {
         region: REGION_NAME,
       };
 
-      const expectedConfig = extend({}, config, {
+      const expectedConfig = Object.assign({}, config, {
         network: network.formattedName,
       });
       delete expectedConfig.region;
@@ -281,7 +280,7 @@ describe('Network', function() {
   describe('getFirewalls', function() {
     it('should make the correct call to Compute', function(done) {
       const options = {a: 'b', c: 'd'};
-      const expectedOptions = extend({}, options, {
+      const expectedOptions = Object.assign({}, options, {
         filter: 'network eq .*' + network.formattedName,
       });
 
@@ -305,7 +304,7 @@ describe('Network', function() {
   describe('getFirewallsStream', function() {
     it('should call to getFirewallsStream correctly', function(done) {
       const options = {a: 'b', c: 'd'};
-      const expectedOptions = extend({}, options, {
+      const expectedOptions = Object.assign({}, options, {
         filter: 'network eq .*' + network.formattedName,
       });
 
@@ -341,7 +340,7 @@ describe('Network', function() {
   describe('getSubnetworks', function() {
     it('should call to compute.getSubnetworks correctly', function(done) {
       const options = {a: 'b', c: 'd'};
-      const expectedOptions = extend({}, options, {
+      const expectedOptions = Object.assign({}, options, {
         filter: 'network eq .*' + network.formattedName,
       });
 
@@ -365,7 +364,7 @@ describe('Network', function() {
   describe('getSubnetworksStream', function() {
     it('should call to getSubnetworksStream correctly', function(done) {
       const options = {a: 'b', c: 'd'};
-      const expectedOptions = extend({}, options, {
+      const expectedOptions = Object.assign({}, options, {
         filter: 'network eq .*' + network.formattedName,
       });
 

--- a/test/operation.js
+++ b/test/operation.js
@@ -17,7 +17,6 @@
 'use strict';
 
 const assert = require('assert');
-const extend = require('extend');
 const proxyquire = require('proxyquire').noPreserveCache();
 const {util} = require('@google-cloud/common');
 const promisify = require('@google-cloud/promisify');
@@ -36,7 +35,7 @@ class FakeServiceObject {
 
 let parseHttpRespBodyOverride = null;
 let promisified = false;
-const fakeUtil = extend({}, util, {
+const fakeUtil = Object.assign({}, util, {
   parseHttpRespBody: function() {
     if (parseHttpRespBodyOverride) {
       return parseHttpRespBodyOverride.apply(null, arguments);
@@ -45,7 +44,7 @@ const fakeUtil = extend({}, util, {
   },
 });
 
-const fakePromisify = extend({}, promisify, {
+const fakePromisify = Object.assign({}, promisify, {
   promisifyAll: function(Class) {
     if (Class.name === 'Operation') {
       promisified = true;

--- a/test/project.js
+++ b/test/project.js
@@ -17,12 +17,11 @@
 'use strict';
 
 const assert = require('assert');
-const extend = require('extend');
 const proxyquire = require('proxyquire');
 const promisify = require('@google-cloud/promisify');
 
 let promisified = false;
-const fakePromisify = extend({}, promisify, {
+const fakePromisify = Object.assign({}, promisify, {
   promisifyAll: function(Class) {
     if (Class.name === 'Project') {
       promisified = true;

--- a/test/region.js
+++ b/test/region.js
@@ -19,13 +19,12 @@
 const arrify = require('arrify');
 const assert = require('assert');
 const {ServiceObject} = require('@google-cloud/common');
-const extend = require('extend');
 const is = require('is');
 const proxyquire = require('proxyquire');
 const promisify = require('@google-cloud/promisify');
 
 let promisified = false;
-const fakePromisify = extend({}, promisify, {
+const fakePromisify = Object.assign({}, promisify, {
   promisifyAll: function(Class, options) {
     if (Class.name !== 'Region') {
       return;
@@ -200,7 +199,7 @@ describe('Region', function() {
   describe('createAddress', function() {
     const NAME = 'address-name';
     const OPTIONS = {a: 'b', c: 'd'};
-    const EXPECTED_BODY = extend({}, OPTIONS, {name: NAME});
+    const EXPECTED_BODY = Object.assign({}, OPTIONS, {name: NAME});
 
     it('should not require any options', function(done) {
       const expectedBody = {name: NAME};
@@ -307,7 +306,7 @@ describe('Region', function() {
       c: 'd',
       network: 'network-name',
     };
-    const EXPECTED_BODY = extend({}, CONFIG, {name: NAME});
+    const EXPECTED_BODY = Object.assign({}, CONFIG, {name: NAME});
 
     it('should make the correct API request', function(done) {
       region.request = function(reqOpts) {
@@ -326,7 +325,7 @@ describe('Region', function() {
         const network = new FakeNetwork();
         network.formattedName = 'formatted-name';
 
-        const config = extend({}, CONFIG, {
+        const config = Object.assign({}, CONFIG, {
           network: network,
         });
 
@@ -341,7 +340,7 @@ describe('Region', function() {
 
     describe('config.range', function() {
       it('should accept and delete a range property', function(done) {
-        const config = extend({}, CONFIG, {
+        const config = Object.assign({}, CONFIG, {
           range: '...',
         });
 
@@ -471,7 +470,7 @@ describe('Region', function() {
 
       it('should build a nextQuery if necessary', function(done) {
         const nextPageToken = 'next-page-token';
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: nextPageToken,
         });
         const expectedNextQuery = {
@@ -570,7 +569,7 @@ describe('Region', function() {
 
       it('should build a nextQuery if necessary', function(done) {
         const nextPageToken = 'next-page-token';
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: nextPageToken,
         });
         const expectedNextQuery = {
@@ -669,7 +668,7 @@ describe('Region', function() {
 
       it('should build a nextQuery if necessary', function(done) {
         const nextPageToken = 'next-page-token';
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: nextPageToken,
         });
         const expectedNextQuery = {
@@ -768,7 +767,7 @@ describe('Region', function() {
 
       it('should build a nextQuery if necessary', function(done) {
         const nextPageToken = 'next-page-token';
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: nextPageToken,
         });
         const expectedNextQuery = {

--- a/test/rule.js
+++ b/test/rule.js
@@ -17,13 +17,12 @@
 'use strict';
 
 const assert = require('assert');
-const extend = require('extend');
 const proxyquire = require('proxyquire');
 const {util} = require('@google-cloud/common');
 const promisify = require('@google-cloud/promisify');
 
 let promisified = false;
-const fakePromisify = extend({}, promisify, {
+const fakePromisify = Object.assign({}, promisify, {
   promisifyAll: function(Class) {
     if (Class.name === 'Rule') {
       promisified = true;
@@ -67,7 +66,7 @@ describe('Rule', function() {
       const computeInstance = new Compute();
       const bindMethod = {};
 
-      extend(computeInstance, {
+      Object.assign(computeInstance, {
         createRule: {
           bind: function(context) {
             assert.strictEqual(context, computeInstance);

--- a/test/service.js
+++ b/test/service.js
@@ -17,13 +17,12 @@
 'use strict';
 
 const assert = require('assert');
-const extend = require('extend');
 const proxyquire = require('proxyquire');
 const {ServiceObject, util} = require('@google-cloud/common');
 const promisify = require('@google-cloud/promisify');
 
 let promisified = false;
-const fakePromisify = extend({}, promisify, {
+const fakePromisify = Object.assign({}, promisify, {
   promisifyAll: function(Class) {
     if (Class.name === 'Service') {
       promisified = true;
@@ -78,7 +77,7 @@ describe('Service', function() {
     it('should inherit from ServiceObject', function() {
       const createMethod = util.noop;
 
-      const computeInstance = extend({}, COMPUTE, {
+      const computeInstance = Object.assign({}, COMPUTE, {
         createService: {
           bind: function(context) {
             assert.strictEqual(context, computeInstance);

--- a/test/snapshot.js
+++ b/test/snapshot.js
@@ -17,13 +17,12 @@
 'use strict';
 
 const assert = require('assert');
-const extend = require('extend');
 const {ServiceObject} = require('@google-cloud/common');
 const proxyquire = require('proxyquire');
 const promisify = require('@google-cloud/promisify');
 
 let promisified = false;
-const fakePromisify = extend({}, promisify, {
+const fakePromisify = Object.assign({}, promisify, {
   promisifyAll: function(Class) {
     if (Class.name === 'Snapshot') {
       promisified = true;

--- a/test/subnetwork.js
+++ b/test/subnetwork.js
@@ -17,13 +17,12 @@
 'use strict';
 
 const assert = require('assert');
-const extend = require('extend');
 const proxyquire = require('proxyquire');
 const {ServiceObject, util} = require('@google-cloud/common');
 const promisify = require('@google-cloud/promisify');
 
 let promisified = false;
-const fakePromisify = extend({}, promisify, {
+const fakePromisify = Object.assign({}, promisify, {
   promisifyAll: function(Class) {
     if (Class.name === 'Subnetwork') {
       promisified = true;
@@ -74,7 +73,7 @@ describe('Subnetwork', function() {
     it('should inherit from ServiceObject', function() {
       const createSubnetworkBound = {};
 
-      const regionInstance = extend({}, REGION, {
+      const regionInstance = Object.assign({}, REGION, {
         createSubnetwork: {
           bind: function(context) {
             assert.strictEqual(context, regionInstance);

--- a/test/vm.js
+++ b/test/vm.js
@@ -24,7 +24,7 @@ const promisify = require('@google-cloud/promisify');
 const {replaceProjectIdToken} = require('@google-cloud/projectify');
 
 let promisified = false;
-const fakePromisify = extend({}, promisify, {
+const fakePromisify = Object.assign({}, promisify, {
   promisifyAll: function(Class) {
     if (Class.name === 'VM') {
       promisified = true;
@@ -135,7 +135,7 @@ describe('VM', function() {
     });
 
     it('should inherit from ServiceObject', function(done) {
-      const zoneInstance = extend({}, ZONE, {
+      const zoneInstance = Object.assign({}, ZONE, {
         createVM: {
           bind: function(context) {
             assert.strictEqual(context, zoneInstance);
@@ -195,7 +195,9 @@ describe('VM', function() {
       const CONFIG = {readOnly: true};
 
       it('should set the correct mode', function(done) {
-        const expectedBody = extend({}, EXPECTED_BODY, {mode: 'READ_ONLY'});
+        const expectedBody = Object.assign({}, EXPECTED_BODY, {
+          mode: 'READ_ONLY',
+        });
 
         vm.request = function(reqOpts) {
           assert.deepStrictEqual(reqOpts.json, expectedBody);

--- a/test/zone.js
+++ b/test/zone.js
@@ -18,14 +18,13 @@
 
 const arrify = require('arrify');
 const assert = require('assert');
-const extend = require('extend');
 const {GCEImages} = require('gce-images');
 const proxyquire = require('proxyquire');
 const {ServiceObject, util} = require('@google-cloud/common');
 const promisify = require('@google-cloud/promisify');
 
 let promisified = false;
-const fakePromisify = extend({}, promisify, {
+const fakePromisify = Object.assign({}, promisify, {
   promisifyAll: function(Class, options) {
     if (Class.name !== 'Zone') {
       return;
@@ -1006,7 +1005,7 @@ describe('Zone', function() {
           selfLink: 'http://selflink',
         };
 
-        const expectedConfig = extend({}, EXPECTED_CONFIG, {
+        const expectedConfig = Object.assign({}, EXPECTED_CONFIG, {
           disks: [
             {
               autoDelete: true,
@@ -1175,7 +1174,7 @@ describe('Zone', function() {
 
       it('should build a nextQuery if necessary', function(done) {
         const nextPageToken = 'next-page-token';
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: nextPageToken,
         });
         const expectedNextQuery = {
@@ -1274,7 +1273,7 @@ describe('Zone', function() {
 
       it('should build a nextQuery if necessary', function(done) {
         const nextPageToken = 'next-page-token';
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: nextPageToken,
         });
         const expectedNextQuery = {
@@ -1373,7 +1372,7 @@ describe('Zone', function() {
 
       it('should build a nextQuery if necessary', function(done) {
         const nextPageToken = 'next-page-token';
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: nextPageToken,
         });
         const expectedNextQuery = {
@@ -1418,7 +1417,7 @@ describe('Zone', function() {
   describe('getMachineTypes', function() {
     it('should make the correct call to Compute', function(done) {
       const options = {a: 'b', c: 'd'};
-      const expectedOptions = extend({}, options, {
+      const expectedOptions = Object.assign({}, options, {
         filter: 'zone eq .*' + zone.name,
       });
 
@@ -1517,7 +1516,7 @@ describe('Zone', function() {
 
       it('should build a nextQuery if necessary', function(done) {
         const nextPageToken = 'next-page-token';
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: nextPageToken,
         });
         const expectedNextQuery = {
@@ -1615,7 +1614,7 @@ describe('Zone', function() {
 
       it('should build a nextQuery if necessary', function(done) {
         const nextPageToken = 'next-page-token';
-        const apiResponseWithNextPageToken = extend({}, apiResponse, {
+        const apiResponseWithNextPageToken = Object.assign({}, apiResponse, {
           nextPageToken: nextPageToken,
         });
         const expectedNextQuery = {


### PR DESCRIPTION
Just swaps `extend` for the native `Object.assign` where possible.