### PR TITLE
feat: allow pollIntervalMs to be configured

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "predocs-test": "npm run docs"
   },
   "dependencies": {
-    "@google-cloud/common": "^2.0.0",
+    "@google-cloud/common": "^2.3.0",
     "@google-cloud/paginator": "^2.0.0",
     "@google-cloud/projectify": "^1.0.0",
     "@google-cloud/promisify": "^1.0.0",

--- a/src/address.js
+++ b/src/address.js
@@ -162,7 +162,7 @@ class Address extends common.ServiceObject {
       id: name,
       createMethod: region.createAddress.bind(region),
       methods: methods,
-      pollIntervalMs: region.compute.pollIntervalMs
+      pollIntervalMs: region.compute.pollIntervalMs,
     });
     /**
      * @name Address#name

--- a/src/address.js
+++ b/src/address.js
@@ -162,6 +162,7 @@ class Address extends common.ServiceObject {
       id: name,
       createMethod: region.createAddress.bind(region),
       methods: methods,
+      pollIntervalMs: region.compute.pollIntervalMs
     });
     /**
      * @name Address#name

--- a/src/autoscaler.js
+++ b/src/autoscaler.js
@@ -177,6 +177,7 @@ class Autoscaler extends common.ServiceObject {
       id: name,
       createMethod: zone.createAutoscaler.bind(zone),
       methods: methods,
+      pollIntervalMs: zone.compute.pollIntervalMs
     });
     /**
      * @name Autoscaler#name

--- a/src/autoscaler.js
+++ b/src/autoscaler.js
@@ -177,7 +177,7 @@ class Autoscaler extends common.ServiceObject {
       id: name,
       createMethod: zone.createAutoscaler.bind(zone),
       methods: methods,
-      pollIntervalMs: zone.compute.pollIntervalMs
+      pollIntervalMs: zone.compute.pollIntervalMs,
     });
     /**
      * @name Autoscaler#name

--- a/src/disk.js
+++ b/src/disk.js
@@ -172,6 +172,7 @@ class Disk extends common.ServiceObject {
       id: name,
       createMethod: zone.createDisk.bind(zone),
       methods: methods,
+      pollIntervalMs: zone.compute.pollIntervalMs
     });
     /**
      * @name Disk#name

--- a/src/disk.js
+++ b/src/disk.js
@@ -172,7 +172,7 @@ class Disk extends common.ServiceObject {
       id: name,
       createMethod: zone.createDisk.bind(zone),
       methods: methods,
-      pollIntervalMs: zone.compute.pollIntervalMs
+      pollIntervalMs: zone.compute.pollIntervalMs,
     });
     /**
      * @name Disk#name

--- a/src/firewall.js
+++ b/src/firewall.js
@@ -165,7 +165,7 @@ class Firewall extends common.ServiceObject {
       id: name,
       createMethod: compute.createFirewall.bind(compute),
       methods: methods,
-      pollIntervalMs: compute.pollIntervalMs
+      pollIntervalMs: compute.pollIntervalMs,
     });
     /**
      * The parent {@link Compute} instance of this {@link Firewall} instance.

--- a/src/firewall.js
+++ b/src/firewall.js
@@ -165,6 +165,7 @@ class Firewall extends common.ServiceObject {
       id: name,
       createMethod: compute.createFirewall.bind(compute),
       methods: methods,
+      pollIntervalMs: compute.pollIntervalMs
     });
     /**
      * The parent {@link Compute} instance of this {@link Firewall} instance.

--- a/src/health-check.js
+++ b/src/health-check.js
@@ -181,7 +181,7 @@ class HealthCheck extends common.ServiceObject {
         compute.createHealthCheck(name, options, callback);
       },
       methods: methods,
-      pollIntervalMs: compute.pollIntervalMs
+      pollIntervalMs: compute.pollIntervalMs,
     });
     /**
      * The parent {@link Compute} instance of this {@link HealthCheck} instance.

--- a/src/health-check.js
+++ b/src/health-check.js
@@ -181,6 +181,7 @@ class HealthCheck extends common.ServiceObject {
         compute.createHealthCheck(name, options, callback);
       },
       methods: methods,
+      pollIntervalMs: compute.pollIntervalMs
     });
     /**
      * The parent {@link Compute} instance of this {@link HealthCheck} instance.

--- a/src/image.js
+++ b/src/image.js
@@ -156,7 +156,7 @@ class Image extends common.ServiceObject {
       id: name,
       createMethod: compute.createImage.bind(compute),
       methods: methods,
-      pollIntervalMs: compute.pollIntervalMs
+      pollIntervalMs: compute.pollIntervalMs,
     });
   }
   /**

--- a/src/image.js
+++ b/src/image.js
@@ -156,6 +156,7 @@ class Image extends common.ServiceObject {
       id: name,
       createMethod: compute.createImage.bind(compute),
       methods: methods,
+      pollIntervalMs: compute.pollIntervalMs
     });
   }
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,8 @@ const Image = require('./image.js');
  *     We will exponentially backoff subsequent requests by default.
  * @property {number} [maxRetries=3] Maximum number of automatic retries
  *     attempted before returning the error.
+ * @property {number} [pollIntervalMs=500] Poll interval for long running
+ *    operations.
  * @property {Constructor} [promise] Custom promise module to use instead of
  *     native Promises.
  * @property {string} [apiEndpoint] The API endpoint of the service used to make requests. Defaults to `compute.googleapis.com`
@@ -88,6 +90,7 @@ class Compute extends common.Service {
       packageJson: require('../package.json'),
     };
     super(config, options);
+    this.pollIntervalMs = options.pollIntervalMs;
   }
   /**
    * Create a firewall.

--- a/src/instance-group-manager.js
+++ b/src/instance-group-manager.js
@@ -140,6 +140,7 @@ class InstanceGroupManager extends common.ServiceObject {
       id: name,
       // createMethod: zone.createInstanceGroupManager.bind(zone),
       methods: methods,
+      pollIntervalMs: zone.compute.pollIntervalMs,
     });
     /**
      * The parent {@link Zone} instance of this {@link InstanceGroup} instance.

--- a/src/instance-group.js
+++ b/src/instance-group.js
@@ -172,6 +172,7 @@ class InstanceGroup extends common.ServiceObject {
       id: name,
       createMethod: zone.createInstanceGroup.bind(zone),
       methods: methods,
+      pollIntervalMs: zone.compute.pollIntervalMs,
     });
     /**
      * The parent {@link Zone} instance of this {@link InstanceGroup} instance.

--- a/src/machine-type.js
+++ b/src/machine-type.js
@@ -128,6 +128,7 @@ class MachineType extends common.ServiceObject {
        */
       id: name,
       methods: methods,
+      pollIntervalMs: zone.compute.pollIntervalMs,
     });
     /**
      * The parent {@link Zone} instance of this {@link MachineType} instance.

--- a/src/network.js
+++ b/src/network.js
@@ -167,6 +167,7 @@ class Network extends common.ServiceObject {
       id: name,
       createMethod: compute.createNetwork.bind(compute),
       methods: methods,
+      pollIntervalMs: compute.pollIntervalMs,
     });
     /**
      * The parent {@link Compute} instance of this {@link Network} instance.

--- a/src/operation.js
+++ b/src/operation.js
@@ -174,6 +174,9 @@ class Operation extends common.Operation {
        */
       id: name,
       methods: methods,
+      pollIntervalMs: isCompute
+        ? scope.pollIntervalMs
+        : scope.compute.pollIntervalMs,
     });
 
     /**

--- a/src/project.js
+++ b/src/project.js
@@ -95,6 +95,7 @@ class Project extends common.ServiceObject {
       baseUrl: '',
       id: '',
       methods: methods,
+      pollIntervalMs: compute.pollIntervalMs,
     });
   }
 }

--- a/src/region.js
+++ b/src/region.js
@@ -131,12 +131,14 @@ class Region extends common.ServiceObject {
        */
       id: name,
       methods: methods,
+      pollIntervalMs: compute.pollIntervalMs,
     });
     /**
      * @name Region#name
      * @type {string}
      */
     this.name = name;
+    this.compute = compute;
     this.interceptors.push({
       request: function(reqOpts) {
         if (reqOpts.uri.indexOf('/global/forwardingRules') > -1) {

--- a/src/rule.js
+++ b/src/rule.js
@@ -186,6 +186,9 @@ class Rule extends common.ServiceObject {
       id: name,
       createMethod: scope.createRule.bind(scope),
       methods: methods,
+      pollIntervalMs: scope.compute
+        ? scope.compute.pollIntervalMs
+        : scope.pollIntervalMs,
     });
     /**
      * @name Rule#scope

--- a/src/service.js
+++ b/src/service.js
@@ -181,6 +181,7 @@ class Service extends common.ServiceObject {
       id: name,
       createMethod: compute.createService.bind(compute),
       methods: methods,
+      pollIntervalMs: compute.pollIntervalMs,
     });
     /**
      * The parent {@link Compute} instance of this {@link Service} instance.

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -134,6 +134,7 @@ class Snapshot extends common.ServiceObject {
        */
       id: name,
       methods: methods,
+      pollIntervalMs: compute.pollIntervalMs,
     };
     if (isDisk) {
       config.createMethod = scope.createSnapshot.bind(scope);

--- a/src/subnetwork.js
+++ b/src/subnetwork.js
@@ -168,6 +168,7 @@ class Subnetwork extends common.ServiceObject {
       id: name,
       createMethod: region.createSubnetwork.bind(region),
       methods: methods,
+      pollIntervalMs: region.compute.pollIntervalMs,
     });
     /**
      * @name Subnetwork#name

--- a/src/vm.js
+++ b/src/vm.js
@@ -233,6 +233,7 @@ class VM extends common.ServiceObject {
       id: name,
       createMethod: zone.createVM.bind(zone),
       methods: methods,
+      pollIntervalMs: zone.compute.pollIntervalMs,
     });
 
     /**

--- a/src/zone.js
+++ b/src/zone.js
@@ -138,6 +138,7 @@ class Zone extends common.ServiceObject {
        */
       id: name,
       methods: methods,
+      pollIntervalMs: compute.pollIntervalMs,
     });
     /**
      * The parent {@link Compute} instance of this {@link Zone} instance.

--- a/test/address.js
+++ b/test/address.js
@@ -42,6 +42,7 @@ describe('Address', function() {
   const ADDRESS_NAME = 'us-central1';
   const REGION = {
     createAddress: () => {},
+    compute: {}
   };
 
   before(function() {

--- a/test/address.js
+++ b/test/address.js
@@ -42,7 +42,7 @@ describe('Address', function() {
   const ADDRESS_NAME = 'us-central1';
   const REGION = {
     createAddress: () => {},
-    compute: {}
+    compute: {},
   };
 
   before(function() {

--- a/test/instance-group-manager.js
+++ b/test/instance-group-manager.js
@@ -41,7 +41,9 @@ describe('InstanceGroupManager', function() {
 
   const staticMethods = {};
 
-  const ZONE = {};
+  const ZONE = {
+    compute: {},
+  };
   const NAME = 'instance-group-manager-name';
 
   before(function() {

--- a/test/instance-group.js
+++ b/test/instance-group.js
@@ -64,6 +64,7 @@ describe('InstanceGroup', function() {
   const ZONE = {
     createInstanceGroup: util.noop,
     vm: util.noop,
+    compute: {},
   };
   const NAME = 'instance-group-name';
 

--- a/test/machine-type.js
+++ b/test/machine-type.js
@@ -31,6 +31,7 @@ describe('MachineType', function() {
   const ZONE_NAME = 'zone-1';
   const ZONE = {
     name: ZONE_NAME,
+    compute: {},
   };
 
   const MACHINE_TYPE_NAME = 'g1-small';

--- a/test/operation.js
+++ b/test/operation.js
@@ -56,6 +56,7 @@ describe('Operation', function() {
 
   const SCOPE = {
     Promise: Promise,
+    compute: {},
   };
   const OPERATION_NAME = 'operation-name';
 

--- a/test/subnetwork.js
+++ b/test/subnetwork.js
@@ -44,6 +44,7 @@ describe('Subnetwork', function() {
   const REGION = {
     createSubnetwork: util.noop,
     name: REGION_NAME,
+    compute: {},
   };
 
   before(function() {


### PR DESCRIPTION
Allows `pollIntervalMs` to be configured for long running operations, when instantiating a `Compute` instance:

```js
new Compute({
  pollIntervalMs: 2000
})
```
