### PR TITLE
test: cleanup logic causes errors

### DIFF
--- a/samples/test/samples.test.js
+++ b/samples/test/samples.test.js
@@ -56,9 +56,12 @@ describe('samples', () => {
     const name = `gcloud-apache-${uuid.v4().split('-')[0]}`;
     after(async () => deleteVM(name));
     it('should create vm with startup script', function() {
+      console.info('start the test');
       this.timeout(280000);
       this.retries(3);
+      console.info('wait on output');
       const output = execSync(`node startupScript ${name}`);
+      console.info('output finished');
       assert.match(output, /created succesfully/);
     });
   });
@@ -69,6 +72,7 @@ describe('samples', () => {
  * @param {string} name
  */
 async function deleteVM(name) {
+  console.info('delete VM');
   const zone = compute.zone('us-central1-c');
   const vm = zone.vm(name);
   const [operation] = await vm.delete();

--- a/samples/test/samples.test.js
+++ b/samples/test/samples.test.js
@@ -59,7 +59,7 @@ describe('samples', () => {
       this.timeout(280000);
       this.retries(3);
       const {spawn} = require('child_process');
-      const startupScript = spawn('ls', ['startupScript', name], {
+      const startupScript = spawn('node', ['startupScript', name], {
         stdio: 'inherit',
       });
       startupScript.on('close', code => {

--- a/samples/test/samples.test.js
+++ b/samples/test/samples.test.js
@@ -55,7 +55,7 @@ describe('samples', () => {
   describe('start-up script', () => {
     const name = `gcloud-apache-${uuid.v4().split('-')[0]}`;
     after(async () => deleteVM(name));
-    it('should create vm with startup script', () => {
+    it('should create vm with startup script', function() {
       this.timeout(280000);
       this.retries(3);
       const output = execSync(`node startupScript ${name}`);

--- a/samples/test/samples.test.js
+++ b/samples/test/samples.test.js
@@ -27,35 +27,37 @@ describe('samples', () => {
   describe('quickstart', () => {
     const name = `gcloud-ubuntu-${uuid.v4().split('-')[0]}`;
     after(async () => deleteVM(name));
-    it('should run the quickstart', async () => {
+    it('should run the quickstart', () => {
       const output = execSync(`node quickstart ${name}`);
       assert.match(output, /Virtual machine created!/);
     });
   });
 
-  describe('lifecycle', async () => {
+  describe('lifecycle', () => {
     const name = `gcloud-ubuntu-${uuid.v4().split('-')[0]}`;
 
-    it('should create a VM', async () => {
+    it('should create a VM', () => {
       const output = execSync(`node createVM ${name}`);
       assert.match(output, /Virtual machine created!/);
     });
 
-    it('should list the VMs', async () => {
+    it('should list the VMs', () => {
       const output = execSync('node listVMs');
       assert.match(output, /Found \d+ VMs!/);
     });
 
-    it('should delete the VM', async () => {
+    it('should delete the VM', () => {
       const output = execSync(`node deleteVM ${name}`);
       assert.match(output, /VM deleted!/);
     });
   });
 
-  describe('start-up script', async () => {
+  describe('start-up script', () => {
     const name = `gcloud-apache-${uuid.v4().split('-')[0]}`;
     after(async () => deleteVM(name));
-    it('should create vm with startup script', async () => {
+    it('should create vm with startup script', () => {
+      this.timeout(280000);
+      this.retries(3);
       const output = execSync(`node startupScript ${name}`);
       assert.match(output, /created succesfully/);
     });

--- a/samples/test/samples.test.js
+++ b/samples/test/samples.test.js
@@ -23,40 +23,42 @@ const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const compute = new Compute();
 
-describe('quickstart', () => {
-  const name = `gcloud-ubuntu-${uuid.v4().split('-')[0]}`;
-  after(async () => deleteVM(name));
-  it('should run the quickstart', async () => {
-    const output = execSync(`node quickstart ${name}`);
-    assert.match(output, /Virtual machine created!/);
-  });
-});
-
-describe('lifecycle', async () => {
-  const name = `gcloud-ubuntu-${uuid.v4().split('-')[0]}`;
-
-  it('should create a VM', async () => {
-    const output = execSync(`node createVM ${name}`);
-    assert.match(output, /Virtual machine created!/);
+describe('samples', () => {
+  describe('quickstart', () => {
+    const name = `gcloud-ubuntu-${uuid.v4().split('-')[0]}`;
+    after(async () => deleteVM(name));
+    it('should run the quickstart', async () => {
+      const output = execSync(`node quickstart ${name}`);
+      assert.match(output, /Virtual machine created!/);
+    });
   });
 
-  it('should list the VMs', async () => {
-    const output = execSync('node listVMs');
-    assert.match(output, /Found \d+ VMs!/);
+  describe('lifecycle', async () => {
+    const name = `gcloud-ubuntu-${uuid.v4().split('-')[0]}`;
+
+    it('should create a VM', async () => {
+      const output = execSync(`node createVM ${name}`);
+      assert.match(output, /Virtual machine created!/);
+    });
+
+    it('should list the VMs', async () => {
+      const output = execSync('node listVMs');
+      assert.match(output, /Found \d+ VMs!/);
+    });
+
+    it('should delete the VM', async () => {
+      const output = execSync(`node deleteVM ${name}`);
+      assert.match(output, /VM deleted!/);
+    });
   });
 
-  it('should delete the VM', async () => {
-    const output = execSync(`node deleteVM ${name}`);
-    assert.match(output, /VM deleted!/);
-  });
-});
-
-describe('start-up script', async () => {
-  const name = `gcloud-apache-${uuid.v4().split('-')[0]}`;
-  after(async () => deleteVM(name));
-  it('should create vm with startup script', async () => {
-    const output = execSync(`node startupScript ${name}`);
-    assert.match(output, /created succesfully/);
+  describe('start-up script', async () => {
+    const name = `gcloud-apache-${uuid.v4().split('-')[0]}`;
+    after(async () => deleteVM(name));
+    it('should create vm with startup script', async () => {
+      const output = execSync(`node startupScript ${name}`);
+      assert.match(output, /created succesfully/);
+    });
   });
 });
 

--- a/samples/test/samples.test.js
+++ b/samples/test/samples.test.js
@@ -55,13 +55,10 @@ describe('samples', () => {
   describe('start-up script', () => {
     const name = `gcloud-apache-${uuid.v4().split('-')[0]}`;
     after(async () => deleteVM(name));
-    it('should create vm with startup script', function() {
-      console.info('start the test');
+    it('should create vm with startup script', async function() {
       this.timeout(280000);
       this.retries(3);
-      console.info('wait on output');
-      const output = execSync(`node startupScript ${name}`);
-      console.info('output finished');
+      const output = execSync(`node startupScript ${name}`, {timeout: 280000});
       assert.match(output, /created succesfully/);
     });
   });

--- a/samples/test/samples.test.js
+++ b/samples/test/samples.test.js
@@ -75,7 +75,6 @@ describe('samples', () => {
  * @param {string} name
  */
 async function deleteVM(name) {
-  console.info('delete VM');
   const zone = compute.zone('us-central1-c');
   const vm = zone.vm(name);
   const [operation] = await vm.delete();

--- a/samples/test/samples.test.js
+++ b/samples/test/samples.test.js
@@ -55,11 +55,17 @@ describe('samples', () => {
   describe('start-up script', () => {
     const name = `gcloud-apache-${uuid.v4().split('-')[0]}`;
     after(async () => deleteVM(name));
-    it('should create vm with startup script', async function() {
+    it('should create vm with startup script', function(done) {
       this.timeout(280000);
       this.retries(3);
-      const output = execSync(`node startupScript ${name}`, {timeout: 280000});
-      assert.match(output, /created succesfully/);
+      const {spawn} = require('child_process');
+      const startupScript = spawn('ls', ['startupScript', name], {
+        stdio: 'inherit',
+      });
+      startupScript.on('close', code => {
+        assert.strictEqual(code, 0);
+        return done();
+      });
     });
   });
 });

--- a/system-test/compute.js
+++ b/system-test/compute.js
@@ -1114,16 +1114,20 @@ describe('Compute', () => {
 
   async function deleteAllTestObjects(opts) {
     opts.name = opts.expiredOnly ? TESTS_PREFIX : FULL_PREFIX;
-    await deleteRegionalRules(opts);
-    await callAndDeleteGcloudTestObject('Rules', opts);
-    await deleteTargetProxies(opts);
-    await deleteUrlMaps(opts);
-    await callAndDeleteGcloudTestObject('Services', opts);
-    await deleteHttpsHealthChecks(opts);
-    await deleteInstanceGroupManagers(opts);
-    await deleteInstanceTemplates(opts);
-    await deleteTargetInstances(opts);
-    await deleteAllGcloudTestObjects(opts);
+    try {
+      await deleteRegionalRules(opts);
+      await callAndDeleteGcloudTestObject('Rules', opts);
+      await deleteTargetProxies(opts);
+      await deleteUrlMaps(opts);
+      await callAndDeleteGcloudTestObject('Services', opts);
+      await deleteHttpsHealthChecks(opts);
+      await deleteInstanceGroupManagers(opts);
+      await deleteInstanceTemplates(opts);
+      await deleteTargetInstances(opts);
+      await deleteAllGcloudTestObjects(opts);
+    } catch (err) {
+      console.warn(err);
+    }
   }
 
   async function deleteAllGcloudTestObjects(opts) {


### PR DESCRIPTION
I'm seeing:

```
     Error: The network resource 'projects/long-door-651/global/networks/gcloud-7cb2678f-network-87525255' is already being used by 'projects/long-door-651/global/firewalls/gcloud-7cb2678f-network-87525255-wxdqry2w4crjze2quc4w4di6'
```

Periodically in the logs, sometimes for the `before` action, and sometimes for the `after`, making me think the cleanup logic is sometimes flaky.
