### PR TITLE
feat: add vm.update() method

### DIFF
--- a/src/vm.js
+++ b/src/vm.js
@@ -17,6 +17,7 @@
 'use strict';
 
 const common = require('@google-cloud/common');
+const extend = require('extend');
 const format = require('string-format-obj');
 const is = require('is');
 const {promisifyAll} = require('@google-cloud/promisify');
@@ -919,6 +920,64 @@ class VM extends common.ServiceObject {
       },
       callback || common.util.noop
     );
+  }
+  /**
+   * Update the instance.
+   *
+   * NOTE: This method will pull the latest record of the current metadata, then
+   * merge it with the object you provide. This means there is a chance of a
+   * mismatch in data if the resource is updated immediately after we pull the
+   * metadata, but before we update it.
+   *
+   * @see [Instances: update API Documentation]{@link https://cloud.google.com/compute/docs/reference/v1/instances/update}
+   *
+   * @param {function=} callback - The callback function.
+   * @param {?error} callback.err - An error returned while making this request.
+   * @param {Operation} callback.operation - An operation object
+   *     that can be used to check the status of the request.
+   * @param {object} callback.apiResponse - The full API response.
+   *
+   * @example
+   * const Compute = require('@google-cloud/compute');
+   * const compute = new Compute();
+   * const zone = compute.zone('zone-name');
+   * const vm = zone.vm('vm-name');
+   *
+   * const metadata = {
+   *   deletionProtection: false,
+   * };
+   *
+   * vm.update(metadata, function(err, operation, apiResponse) {
+   *   // `operation` is an Operation object that can be used to check the
+   *   // status of the request.
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * vm.update(metadata).then(function(data) {
+   *   const operation = data[0];
+   *   const apiResponse = data[1];
+   * });
+   */
+  update(metadata, callback) {
+    callback = callback || common.util.noop;
+
+    this.getMetadata((err, currentMetadata) => {
+      if (err) {
+        callback(err);
+        return;
+      }
+
+      this.request(
+        {
+          method: 'PUT',
+          uri: '',
+          json: extend(true, currentMetadata, metadata),
+        },
+        callback
+      );
+    });
   }
   /**
    * This function will callback when the VM is in the specified state.

--- a/system-test/compute.js
+++ b/system-test/compute.js
@@ -1021,6 +1021,12 @@ describe('Compute', () => {
       assert.deepStrictEqual(vm.metadata.metadata.items, [{key, value}]);
     });
 
+    it('should update the VM', async () => {
+      await awaitResult(vm.update({deletionProtection: false}));
+      const [metadata] = await vm.getMetadata();
+      assert.strictEqual(metadata.deletionProtection, false);
+    });
+
     it('should allow updating old metadata', async () => {
       const key = 'newKey';
       const value = 'newValue';


### PR DESCRIPTION
Fixes #477 

We currently have a "setMetadata()" method on our VM class. Unlike our other methods by the same name, the VM's will not update the remote resource as a whole-- instead, it only updates the metadata object within the resource. In other words, a VM's structure looks like:

```json
{
  "name": "...",
  "deletionProtection": false,
  "metadata": {
    "myCustomProperty": true
  }
}
```

`vm.setMetadata()` will only change the "metadata" object. This PR adds `vm.update()`, which has control of the whole thing.

Things to note:

- `vm.getMetadata()` returns the whole record, not just the embedded "metadata" object.
- `vm.update()` is not atomic. It pulls the latest metadata, merges with the new, then sends the update in another call.