### PR TITLE
fix: handle parameters to image.create()

### DIFF
--- a/src/image.js
+++ b/src/image.js
@@ -38,37 +38,6 @@ class Image extends common.ServiceObject {
   constructor(compute, name) {
     const methods = {
       /**
-       * Create an image.
-       *
-       * @method Image#create
-       * @param {Disk} disk - See {@link Compute#createImage}.
-       * @param {object} [options] - See {@link Compute#createImage}.
-       *
-       * @example
-       * const Compute = require('@google-cloud/compute');
-       * const compute = new Compute();
-       * const zone = compute.zone('us-central1-a');
-       * const disk = zone.disk('disk1');
-       * const image = compute.image('image-name');
-       *
-       * image.create(disk, function(err, image, operation, apiResponse) {
-       *   // `image` is an Image object.
-       *
-       *   // `operation` is an Operation object that can be used to check the
-       *   // status of the request.
-       * });
-       *
-       * //-
-       * // If the callback is omitted, we'll return a Promise.
-       * //-
-       * image.create(disk).then(function(data) {
-       *   const image = data[0];
-       *   const operation = data[1];
-       *   const apiResponse = data[2];
-       * });
-       */
-      create: true,
-      /**
        * Check if the image exists.
        *
        * @method Image#exists
@@ -154,11 +123,45 @@ class Image extends common.ServiceObject {
        * @type {string}
        */
       id: name,
-      createMethod: compute.createImage.bind(compute),
       methods: methods,
       pollIntervalMs: compute.pollIntervalMs,
     });
   }
+
+  /**
+   * Create an image.
+   *
+   * @method Image#create
+   * @param {Disk} disk - See {@link Compute#createImage}.
+   * @param {object} [options] - See {@link Compute#createImage}.
+   *
+   * @example
+   * const Compute = require('@google-cloud/compute');
+   * const compute = new Compute();
+   * const zone = compute.zone('us-central1-a');
+   * const disk = zone.disk('disk1');
+   * const image = compute.image('image-name');
+   *
+   * image.create(disk, function(err, image, operation, apiResponse) {
+   *   // `image` is an Image object.
+   *
+   *   // `operation` is an Operation object that can be used to check the
+   *   // status of the request.
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * image.create(disk).then(function(data) {
+   *   const image = data[0];
+   *   const operation = data[1];
+   *   const apiResponse = data[2];
+   * });
+   */
+  create(disk, options, callback) {
+    this.parent.createImage(this.id, disk, options, callback);
+  }
+
   /**
    * Delete the image.
    *

--- a/src/index.js
+++ b/src/index.js
@@ -329,8 +329,9 @@ class Compute extends common.Service {
    * // If the callback is omitted, we'll return a Promise.
    * //-
    * compute.createImage('new-image', disk).then(function(data) {
-   *   var operation = data[0];
-   *   var apiResponse = data[1];
+   *   var image = data[0];
+   *   var operation = data[1];
+   *   var apiResponse = data[2];
    * });
    */
   createImage(name, disk, options, callback) {

--- a/system-test/compute.js
+++ b/system-test/compute.js
@@ -384,6 +384,12 @@ describe('Compute', () => {
       assert.strictEqual(exists, true);
     });
 
+    it('should create an image from an image object', async () => {
+      const image = compute.image(generateName('image'));
+      const [, operation] = await image.create(DISK, {labels: {a: 'b'}});
+      await operation.promise();
+    });
+
     it('should list images', async () => {
       const [images] = await compute.getImages();
       assert(images.length > 0);

--- a/test/image.js
+++ b/test/image.js
@@ -41,7 +41,6 @@ describe('Image', () => {
 
   const COMPUTE = {
     projectId: 'project-id',
-    createImage: util.noop,
     operation: util.noop,
   };
   const IMAGE_NAME = 'image-name';
@@ -66,13 +65,7 @@ describe('Image', () => {
     });
 
     it('should inherit from ServiceObject', () => {
-      const computeInstance = Object.assign({}, COMPUTE, {
-        createImage: {
-          bind: function (context) {
-            assert.strictEqual(context, computeInstance);
-          },
-        },
-      });
+      const computeInstance = Object.assign({}, COMPUTE);
 
       const image = new Image(computeInstance, IMAGE_NAME);
       assert(image instanceof ServiceObject);
@@ -83,11 +76,26 @@ describe('Image', () => {
       assert.strictEqual(calledWith.baseUrl, '/global/images');
       assert.strictEqual(calledWith.id, IMAGE_NAME);
       assert.deepStrictEqual(calledWith.methods, {
-        create: true,
         exists: true,
         get: true,
         getMetadata: true,
       });
+    });
+  });
+
+  describe('create', () => {
+    it('should pass correct arguments to compute.createImage method', done => {
+      const disk = {};
+      const options = {};
+
+      image.parent.createImage = (id, disk_, options_, callback) => {
+        assert.strictEqual(id, image.id);
+        assert.strictEqual(disk_, disk);
+        assert.strictEqual(options_, options);
+        callback(); // done()
+      };
+
+      image.create(disk, options, done);
     });
   });
 


### PR DESCRIPTION
Fixes #540 

`image.create()` accepts one too many parameters for what `ServiceObject.create()` was designed to support. This PR adds a new `create()` method to bypass it.