### PR TITLE
fix(disks): attach default disk first if needed

### DIFF
--- a/src/zone.js
+++ b/src/zone.js
@@ -649,13 +649,17 @@ class Zone extends common.ServiceObject {
         }
         delete body.os;
         body.disks = body.disks || [];
-        body.disks.unshift({
-          autoDelete: true,
-          boot: true,
-          initializeParams: {
-            sourceImage: image.selfLink,
-          },
-        });
+        // Only push an additional disk configuration if the disk provided
+        // is not bootable:
+        if (body.disks.length === 0 || !body.disks[0].boot) {
+          body.disks.unshift({
+            autoDelete: true,
+            boot: true,
+            initializeParams: {
+              sourceImage: image.selfLink,
+            },
+          });
+        }
         self.createVM(name, body, callback);
       });
       return;

--- a/src/zone.js
+++ b/src/zone.js
@@ -649,7 +649,7 @@ class Zone extends common.ServiceObject {
         }
         delete body.os;
         body.disks = body.disks || [];
-        body.disks.push({
+        body.disks.unshift({
           autoDelete: true,
           boot: true,
           initializeParams: {


### PR DESCRIPTION
Allows a user to provide alternative disk configurations, without getting the error:

`Boot disk must be the first disk attached to the instance.`.

Fixes #518