### PR TITLE
test: address race condition with setUsageExportBucket

### DIFF
--- a/samples/test/samples.test.js
+++ b/samples/test/samples.test.js
@@ -99,7 +99,11 @@ describe('samples', () => {
 
   describe('usage export', () => {
     before(async () => {
-      await storage.createBucket(bucketName);
+      try {
+        await storage.createBucket(bucketName);
+      } catch (err) {
+        // Resource likely already existed due to retry.
+      }
     });
 
     after(async () => {

--- a/samples/test/samples.test.js
+++ b/samples/test/samples.test.js
@@ -118,7 +118,7 @@ describe('samples', () => {
 
       const usageExportLocation = project.usageExportLocation;
 
-      assert.equal(usageExportLocation.bucketName, bucketName);
+      assert.match(usageExportLocation.bucketName, /test-bucket-name/);
       assert.equal(usageExportLocation.reportNamePrefix, '');
     });
 

--- a/samples/test/samples.test.js
+++ b/samples/test/samples.test.js
@@ -113,7 +113,7 @@ describe('samples', () => {
       await storage.bucket(bucketName).delete();
     });
 
-    it('should set empty default value in reportNamePrefix', function() {
+    it('should set empty default value in reportNamePrefix', async function () {
       this.retries(3);
       await delay(this.test);
       const projectId = await instancesClient.getProjectId();
@@ -138,7 +138,7 @@ describe('samples', () => {
       assert.equal(usageExportLocation.reportNamePrefix, '');
     });
 
-    it('should get current default value in reportNamePrefix', function () {
+    it('should get current default value in reportNamePrefix', async function () {
       this.retries(3);
       await delay(this.test);
       const projectId = await instancesClient.getProjectId();
@@ -155,7 +155,7 @@ describe('samples', () => {
       assert.match(output, /Returned reportNamePrefix: usage_gce/);
     });
 
-    it('should disable usage export', function () {
+    it('should disable usage export', async function () {
       this.retries(3);
       await delay(this.test);
       const projectId = await instancesClient.getProjectId();

--- a/samples/test/samples.test.js
+++ b/samples/test/samples.test.js
@@ -27,6 +27,20 @@ const projectsClient = new compute.ProjectsClient({fallback: 'rest'});
 
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
+// A helper for delaying integration tests with an exponential backoff.
+// See examples like: https://github.com/googleapis/nodejs-monitoring/issues/190,
+// https://github.com/googleapis/nodejs-monitoring/issues/191.
+const delay = async test => {
+  const retries = test.currentRetry();
+  if (retries === 0) return; // no retry on the first failure.
+  // see: https://cloud.google.com/storage/docs/exponential-backoff:
+  const ms = Math.pow(2, retries) * 500 + Math.random() * 1000;
+  return new Promise(done => {
+    console.info(`retrying "${test.title}" in ${ms}ms`);
+    setTimeout(done, ms);
+  });
+};
+
 describe('samples', () => {
   const instanceName = `gcloud-test-intance-${uuid.v4().split('-')[0]}`;
   const zone = 'europe-central2-b';
@@ -99,7 +113,9 @@ describe('samples', () => {
       await storage.bucket(bucketName).delete();
     });
 
-    it('should set empty default value in reportNamePrefix', async () => {
+    it('should set empty default value in reportNamePrefix', function() {
+      this.retries(3);
+      await delay(this.test);
       const projectId = await instancesClient.getProjectId();
 
       const output = execSync(
@@ -122,7 +138,9 @@ describe('samples', () => {
       assert.equal(usageExportLocation.reportNamePrefix, '');
     });
 
-    it('should get current default value in reportNamePrefix', async () => {
+    it('should get current default value in reportNamePrefix', function () {
+      this.retries(3);
+      await delay(this.test);
       const projectId = await instancesClient.getProjectId();
 
       execSync(`node setUsageExportBucket ${projectId} ${bucketName}`);
@@ -137,7 +155,9 @@ describe('samples', () => {
       assert.match(output, /Returned reportNamePrefix: usage_gce/);
     });
 
-    it('should disable usage export', async () => {
+    it('should disable usage export', function () {
+      this.retries(3);
+      await delay(this.test);
       const projectId = await instancesClient.getProjectId();
 
       execSync(`node setUsageExportBucket ${projectId} ${bucketName}`);


### PR DESCRIPTION
Setting setUsageExportBucket appears to be a global setting, this means that if two suites of tests are running in parallel they compete and can clobber each other's value.

Adds retry with and jitter, to hopefully make these collisions less likely.

Fixes #621